### PR TITLE
feat(backend): implement GitHub OAuth validation and db integration (Issue #4)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4434,7 +4434,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },

--- a/backend/src/users/data/user.schema.ts
+++ b/backend/src/users/data/user.schema.ts
@@ -10,6 +10,9 @@ export class User {
 
   @Prop({ required: true })
   passwordHash!: string;
+
+  @Prop({ required: false })
+  githubAccountId?: string;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,0 +1,64 @@
+import { 
+  Controller, 
+  Post, 
+  Param, 
+  Body, 
+  UseGuards, 
+  Request, 
+  ForbiddenException, 
+  UnauthorizedException 
+} from '@nestjs/common';
+import { UsersService } from './users.service';
+import { AuthGuard } from '@nestjs/passport';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  
+  @UseGuards(AuthGuard('jwt')) 
+  @Post(':userId/integrations/github')
+  async linkGithub(
+    @Param('userId') userId: string,
+    @Request() req: any,
+    @Body('oauthAccessToken') oauthAccessToken: string,
+  ) {
+    
+    const tokenUserId = req.user.userId || req.user.sub || req.user._id;
+    if (tokenUserId !== userId) {
+      throw new ForbiddenException('You are not allowed to update this user\'s integrations.');
+    }
+
+    if (!oauthAccessToken) {
+      throw new UnauthorizedException('GitHub oauthAccessToken is required.');
+    }
+
+    try {
+      const githubResponse = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${oauthAccessToken}`,
+          Accept: 'application/vnd.github.v3+json',
+        },
+      });
+
+      if (!githubResponse.ok) {
+        throw new UnauthorizedException('Invalid GitHub access token.');
+      }
+
+      const githubUserData = await githubResponse.json();
+      const githubAccountId = githubUserData.id.toString();
+
+      await this.usersService.linkGithubAccount(userId, githubAccountId);
+
+      return { 
+        success: true, 
+        message: 'GitHub credentials securely processed and stored.' 
+      };
+    } catch (error) {
+      if (error instanceof UnauthorizedException || error instanceof ForbiddenException) {
+        throw error;
+      }
+      throw new UnauthorizedException('Failed to validate token with GitHub API.');
+    }
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { User, UserSchema } from './data/user.schema';
 import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
   ],
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -19,4 +19,12 @@ export class UsersService {
       passwordHash: params.passwordHash,
     });
   }
+
+  async linkGithubAccount(userId: string, githubAccountId: string) {
+    return this.userModel.findByIdAndUpdate(
+      userId,
+      { githubAccountId },
+      { new: true }
+    ).exec();
+  }
 }


### PR DESCRIPTION
## Description
This PR resolves Issue #4 (Backend - GitHub OAuth Integration Validation) by implementing the backend logic to securely process and store a user's GitHub OAuth credentials.

## Changes Made
* **`user.schema.ts`**: Added the `githubAccountId` field to store the linked GitHub ID.
* **`users.service.ts`**: Implemented the `linkGithubAccount` method to update the user's document in the database.
* **`users.controller.ts`**: Created the `POST /users/{userId}/integrations/github` endpoint, protected by `JwtAuthGuard`.
* **`users.module.ts`**: Registered the new `UsersController`.

## Acceptance Criteria Met
- [x] Endpoint rejects requests lacking a valid Bearer token (returns 401 Unauthorized).
- [x] Endpoint rejects requests if the token's `userId` does not match the path parameter (returns 403 Forbidden).
- [x] Successfully validates the incoming `oauthAccessToken` with the GitHub API.
- [x] Successfully updates the database with the verified GitHub ID and returns a 200 OK response.

## Related Issues
Closes #4