### PR TITLE
Docs: update Process 4 & 5 API specs

### DIFF
--- a/docs/api/api-specs/process4.1.yaml
+++ b/docs/api/api-specs/process4.1.yaml
@@ -6,6 +6,10 @@ info:
     approval/rejection, team release, and advisor transfer operations
     (docs/system-processes.md — Process 4).
 
+    Authorization policy: canonical role names are uppercase
+    (COORDINATOR, TEAM_LEADER, ADVISOR, ADMIN, STUDENT).
+    [ANY] means any authenticated role with a valid JWT.
+
     Cross-service dependency: The Committee Assignment API (Process 5) queries
     GET /schedules/active on this service to enforce assignment window constraints
     before assigning groups to committees.
@@ -40,22 +44,17 @@ paths:
   /advisors:
     get:
       tags: [advisors]
-      summary: Query available advisors (role = PROFESSOR)
+      summary: Query available advisors
       operationId: fetchAdvisors
       security:
         - BearerAuth: []
       description: |
-        Fetches users from the Users Database where role == PROFESSOR.
-        Called by the Coordinator to see who is available. Includes pagination.
+        **Requires Role:** [COORDINATOR, TEAM_LEADER]
+
+        Fetches users from the Users Database where role == ADVISOR.
+        Called by Coordinators and Team Leaders to see who is available.
+        Includes pagination.
       parameters:
-        - name: role
-          in: query
-          required: false
-          schema:
-            type: string
-            enum: [PROFESSOR]
-            default: PROFESSOR
-          description: Filter users by role.
         - name: page
           in: query
           required: false
@@ -75,15 +74,15 @@ paths:
           description: The number of advisors to return per page.
       responses:
         "200":
-          description: List of available advisors
+          description: Paginated list of available advisors
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Advisor"
+                $ref: "#/components/schemas/PaginatedAdvisors"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -93,13 +92,23 @@ paths:
   /schedules:
     post:
       tags: [schedule]
-      summary: Set a schedule with start/end datetime
+      summary: Set a schedule window for a specific phase
       operationId: setSchedule
       security:
         - BearerAuth: []
       description: |
-        Coordinator sets the schedule window. Persists schedule constraints 
-        to the Association Database (D1).
+        **Requires Role:** [COORDINATOR]
+
+        Sets the schedule window (start and end dates) for a specific system phase.
+        **Important:** The frontend must send `"phase": "ADVISOR_SELECTION"` in the request body for Process 4.
+        
+        **Preconditions (_requires_):**
+        - The `endDatetime` MUST be strictly after the `startDatetime`.
+        - Caller must have the COORDINATOR role.
+        
+        **Postconditions (_effects_):**
+        - The new schedule is persisted in the Database.
+        - Any previously active schedule for this specific `phase` is overridden or marked as historical.
       requestBody:
         required: true
         content:
@@ -114,34 +123,50 @@ paths:
               schema:
                 $ref: "#/components/schemas/Schedule"
         "400":
-          $ref: "#/components/responses/BadRequest"
+          description: Bad Request – e.g., end date is before start date.
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Forbidden – Caller does not have the COORDINATOR role.
         "500":
           $ref: "#/components/responses/InternalError"
 
   /schedules/active:
     get:
       tags: [schedule]
-      summary: Get the currently active schedule window
+      summary: Get the currently active schedule window for a phase
       operationId: getActiveSchedule
       security:
         - BearerAuth: []
       description: |
-        Returns the currently active schedule window if one exists.
-        Used by Team Leaders to check whether the advisor request window
-        is currently open before attempting to submit a request.
+        **Requires Role:** [ANY]
+
+        Returns the currently active schedule window for the requested phase.
+        This is a convenience endpoint so clients don't have to fetch all historical schedules.
+        
+        - Team Leaders use `?phase=ADVISOR_SELECTION` before sending advisor requests.
+        - Coordinators use `?phase=COMMITTEE_ASSIGNMENT` before assigning groups to committees.
+      parameters:
+        - name: phase
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [ADVISOR_SELECTION, COMMITTEE_ASSIGNMENT]
+          description: Specify which schedule phase you are querying.
       responses:
         "200":
-          description: The active schedule window
+          description: The active schedule window for the requested phase
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ActiveSchedule"
-        "404":
-          description: No active schedule window found
+        "400":
+          description: Bad Request – Phase parameter is missing or invalid.
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Not Found – No active schedule window currently exists for this phase.
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -156,25 +181,21 @@ paths:
       security:
         - BearerAuth: []
       description: |
+        **Requires Role:** [COORDINATOR, ADVISOR, TEAM_LEADER]
+
         Fetches a list of advisor requests. Supports query parameters for filtering.
-        - Team Leaders can filter by their `groupId` to see their pending/past requests.
-        - Advisors can filter by `requestedAdvisorId` to see requests assigned to them.
-        - Coordinators can omit all filters to retrieve all requests across every group.
+        - **TEAM_LEADER**: automatically scoped to their own group. 
+          `groupId` filter is ignored — server enforces it from JWT.
+        - **ADVISOR**: can filter by their own `requestedAdvisorId` only.
+        - **COORDINATOR**: can filter across all groups freely.
       parameters:
-        - name: groupId
-          in: query
-          required: false
-          schema:
-            type: string
-            format: uuid
-          description: Filter requests by the requesting group's ID
         - name: requestedAdvisorId
           in: query
           required: false
           schema:
             type: string
             format: uuid
-          description: Filter requests assigned to a specific advisor
+          description: Filter by advisor. ADVISOR role is automatically scoped to their own userId from JWT.
         - name: status
           in: query
           required: false
@@ -205,13 +226,13 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/AdvisorRequest"
+                $ref: "#/components/schemas/AdvisorRequestList"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -222,9 +243,16 @@ paths:
       security:
         - BearerAuth: []
       description: |
+        **Requires Role:** [TEAM_LEADER]
+
         Team Leader submits a request for a specific advisor. 
-        Inserts a pending request record in the Association Database (D1)
-        and triggers a notification via 4.6 Dispatch Notifications.
+        Inserts a pending request record in the Association Database (D1).
+
+        **Preconditions (_requires_):**
+        - The current server time MUST fall within an active `ADVISOR_SELECTION` schedule window.
+
+        **Postconditions (_effects_):**
+        - Triggers an internal notification to the requested advisor (e.g., email or in-app) about the new request.
       requestBody:
         required: true
         content:
@@ -242,23 +270,32 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "409":
           description: Conflict – a pending request already exists for this group
         "423":
-          description: Locked – group is currently assigned to an advisor. The advisor must release the group before a new request can be submitted.
+          description: Locked – group is currently assigned to an advisor, or schedule window is closed.
         "500":
           $ref: "#/components/responses/InternalError"
 
   /requests/{requestId}:
-    delete:
+    patch:
       tags: [requests]
-      summary: Withdraw (delete) a pending advisor request
-      operationId: withdrawRequest
+      summary: Update the status of an advisor request (e.g. withdraw)
+      operationId: updateRequestStatus
       security:
         - BearerAuth: []
       description: |
-        Team Leader withdraws a previously submitted request by Request ID. 
-        Deletes the pending request record from the Association Database (D1).
+        **Requires Role:** [TEAM_LEADER]
+
+        Updates the status of an existing advisor request.
+        Currently supports transitioning a PENDING request to WITHDRAWN.
+        The record is preserved for history — it is not deleted.
+
+        **Preconditions (_requires_):**
+        - The request status MUST be PENDING.
+        - Caller must be the Team Leader of the group that submitted the request.
       parameters:
         - name: requestId
           in: path
@@ -266,14 +303,28 @@ paths:
           schema:
             type: string
             format: uuid
-          description: The ID of the request to withdraw
+          description: The ID of the request to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateRequestStatus"
       responses:
-        "204":
-          description: Request withdrawn successfully (no content)
-        "404":
-          description: Request not found
+        "200":
+          description: Request status updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdvisorRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Conflict – Cannot withdraw a request that is not PENDING.
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -288,8 +339,21 @@ paths:
       security:
         - BearerAuth: []
       description: |
+        **Requires Role:** [ADVISOR]
+
         An Advisor approves or rejects a pending request.
         Identity is verified via the Bearer token to ensure they own the request.
+
+        **Postconditions (_effects_):**
+        If APPROVE: 
+        - Group status changes to ASSIGNED.
+        - All other pending requests made by this group are automatically denied.
+        - Triggers an approval notification to the advisor.
+
+        If REJECT:
+        - This request status is set to REJECTED.
+        - Group remains UNASSIGNED and may submit a new request within the schedule window.
+        - Triggers a rejection notification to the Team Leader.
       parameters:
         - name: requestId
           in: path
@@ -317,23 +381,28 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: Request not found
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
 
   # ─────────────────────────────────────────────
   # 4.4 Release Team
   # ─────────────────────────────────────────────
-  /advisors/{advisorId}/groups/{groupId}/release:
-    post:
+  /advisors/{advisorId}/groups/{groupId}:
+    delete:
       tags: [release]
-      summary: Release a group from an advisor
+      summary: Remove the association between an advisor and a group (Release)
       operationId: releaseTeam
       security:
         - BearerAuth: []
       description: |
-        Coordinator (or system) releases a group from its current advisor. 
+        **Requires Role:** [COORDINATOR, ADVISOR]
+
+        Releases a group from its current advisor by deleting the relationship resource.
         Updates group status to UNASSIGNED in the Association Database (D1).
+
+        **Preconditions (_requires_):**
+        - Caller must be a Coordinator OR the specific Advisor currently assigned to the team.
       parameters:
         - name: advisorId
           in: path
@@ -349,36 +418,28 @@ paths:
             type: string
             format: uuid
           description: The ID of the group to be released
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                releaseCommand:
-                  type: string
-                  description: Optional release reason or command identifier
       responses:
         "200":
-          description: Group released – status set to UNASSIGNED
+          description: Group released – status set to UNASSIGNED. If the group is already UNASSIGNED, the system treats this as a successful idempotent behaviour.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GroupStatus"
+                $ref: "#/components/schemas/GroupAssignmentStatus"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403": 
+          $ref: "#/components/responses/Forbidden"
         "404":
-          description: Advisor or group not found
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
 
   # ─────────────────────────────────────────────
-  # 4.5 Transfer Advisor
+  # 4.5 & 4.6 Update Group (for Transfer & Disband)
   # ─────────────────────────────────────────────
-  /groups/{groupId}/transfer-advisor:
+  /groups/{groupId}/advisor:
     patch:
       tags: [transfer]
       summary: Transfer a group to a new advisor
@@ -386,8 +447,16 @@ paths:
       security:
         - BearerAuth: []
       description: |
-        Coordinator transfers a group's association from the current advisor 
-        to a new advisor. Updates the Association Record in D1.
+        **Requires Role:** [COORDINATOR]
+
+        Coordinator transfers a group from its current advisor to a new one.
+
+        **Preconditions (_requires_):**
+        - `newAdvisorId` MUST NOT equal the current advisor's ID.
+
+        **Postconditions (_effects_):**
+        - Triggers removal notification to old advisor.
+        - Triggers assignment notification to new advisor.
       parameters:
         - name: groupId
           in: path
@@ -408,13 +477,56 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AssociationRecord"
+                $ref: "#/components/schemas/GroupAssignmentStatus"
         "400":
-          $ref: "#/components/responses/BadRequest"
+          description: Bad Request – e.g., transferring to the same advisor.
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           description: Group or advisor not found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /groups/{groupId}:
+    delete:
+      tags: [groups]
+      summary: Disband a group
+      operationId: disbandGroup
+      security:
+        - BearerAuth: []
+      description: |
+        **Requires Role:** [COORDINATOR]
+
+        Coordinator disbands a group entirely.
+
+        **Preconditions (_requires_):**
+        - Group status MUST be UNASSIGNED. Release the advisor first if currently ASSIGNED.
+
+        **Postconditions (_effects_):**
+        - All students in the group have their `groupId` set to null.
+        - All pending advisor requests for this group are auto-deleted.
+        - Group status is marked as DISBANDED.
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The ID of the group to disband
+      responses:
+        "204":
+          description: Group disbanded successfully (no content)
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Forbidden – group is currently ASSIGNED. Release the advisor first.
+        "404":
+          description: Group not found
+        "409":
+          description: Conflict – group is currently ASSIGNED and cannot be disbanded.
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -429,6 +541,8 @@ paths:
       security:
         - BearerAuth: []
       description: |
+        **Requires Role:** [ANY]
+
         Returns the current advisor assignment status for a group.
         Used by Team Leaders to check whether their group is currently
         ASSIGNED (and therefore blocked from submitting a new request)
@@ -457,56 +571,6 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  /groups/{groupId}/disband:
-    post:
-      tags: [groups]
-      summary: Disband a group that has no advisor
-      operationId: disbandGroup
-      security:
-        - BearerAuth: []
-      description: |
-        Coordinator disbands a group that remains UNASSIGNED (no advisor).
-        Per project rules, groups without an advisor must be disbanded.
-        This endpoint can be triggered manually by the Coordinator or called
-        by the system after a release leaves a group without an advisor.
-        Marks the group as DISBANDED in the Association Database (D1).
-      parameters:
-        - name: groupId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-          description: The ID of the group to disband
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                reason:
-                  type: string
-                  description: Optional reason for disbanding the group
-      responses:
-        "200":
-          description: Group disbanded successfully
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GroupAssignmentStatus"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "404":
-          description: Group not found
-        "409":
-          description: Conflict – group is currently ASSIGNED to an advisor and cannot be disbanded
-        "500":
-          $ref: "#/components/responses/InternalError"
 components:
   schemas:
     Advisor:
@@ -515,14 +579,18 @@ components:
         advisorId:
           type: string
           format: uuid
+          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
         name:
           type: string
+          example: "Dr. Alan Turing"
         email:
           type: string
           format: email
+          example: "aturing@university.edu"
         role:
           type: string
-          enum: [PROFESSOR]
+          enum: [ADVISOR]
+          example: "ADVISOR"
       required: [advisorId, name, role]
 
     SetScheduleRequest:
@@ -536,7 +604,12 @@ components:
           type: string
           format: date-time
           description: Schedule window end
-      required: [startDatetime, endDatetime]
+        phase:
+          type: string
+          enum: [ADVISOR_SELECTION, COMMITTEE_ASSIGNMENT]
+          description: Indicates which process this schedule applies to.
+          example: "ADVISOR_SELECTION"
+      required: [startDatetime, endDatetime, phase]
 
     Schedule:
       type: object
@@ -553,9 +626,14 @@ components:
         endDatetime:
           type: string
           format: date-time
+        phase:
+          type: string
+          enum: [ADVISOR_SELECTION, COMMITTEE_ASSIGNMENT]
+          description: The specific project phase this schedule dictates.
         createdAt:
           type: string
           format: date-time
+      required: [scheduleId, coordinatorId, startDatetime, endDatetime, phase, createdAt]
 
     ActiveSchedule:
       type: object
@@ -573,26 +651,26 @@ components:
         endDatetime:
           type: string
           format: date-time
+        phase:
+          type: string
+          enum: [ADVISOR_SELECTION, COMMITTEE_ASSIGNMENT]
         isOpen:
           type: boolean
           description: True if the current server time falls within the start/end window
         createdAt:
           type: string
           format: date-time
-      required: [scheduleId, startDatetime, endDatetime, isOpen]
+      required: [scheduleId, startDatetime, endDatetime, phase, isOpen]
 
     SubmitRequestBody:
       type: object
       properties:
-        groupId:
-          type: string
-          format: uuid
-          description: ID of the team/group making the request
         requestedAdvisorId:
           type: string
           format: uuid
           description: ID of the advisor being requested
-      required: [groupId, requestedAdvisorId]
+          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+      required: [requestedAdvisorId]
 
     AdvisorRequest:
       type: object
@@ -603,6 +681,10 @@ components:
         groupId:
           type: string
           format: uuid
+        submittedBy:
+          type: string
+          format: uuid
+          description: userId of the Team Leader who submitted the request (from JWT at submission time)
         requestedAdvisorId:
           type: string
           format: uuid
@@ -624,23 +706,6 @@ components:
           enum: [APPROVE, REJECT]
           description: The advisor's decision on the request
       required: [decision]
-
-    GroupStatus:
-      type: object
-      properties:
-        groupId:
-          type: string
-          format: uuid
-        status:
-          type: string
-          enum: [ASSIGNED, UNASSIGNED, DISBANDED]
-        advisorId:
-          type: string
-          format: uuid
-          nullable: true
-        updatedAt:
-          type: string
-          format: date-time
 
     GroupAssignmentStatus:
       type: object
@@ -674,6 +739,16 @@ components:
           format: date-time
       required: [groupId, status, canSubmitRequest]
 
+    UpdateRequestStatus:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [WITHDRAWN]
+          description: The target status to transition the request to.
+          example: "WITHDRAWN"
+      required: [status]
+
     TransferAdvisorRequest:
       type: object
       properties:
@@ -687,25 +762,37 @@ components:
           description: ID of the new advisor to assign
       required: [currentAdvisorId, newAdvisorId]
 
-    AssociationRecord:
+    PaginatedAdvisors:
       type: object
       properties:
-        associationId:
-          type: string
-          format: uuid
-        groupId:
-          type: string
-          format: uuid
-        advisorId:
-          type: string
-          format: uuid
-        status:
-          type: string
-          enum: [ASSIGNED, UNASSIGNED, DISBANDED]
-        transferredAt:
-          type: string
-          format: date-time
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Advisor"
+        total:
+          type: integer
+          description: Total number of records matching the filter
+        page:
+          type: integer
+        limit:
+          type: integer
+      required: [data, total, page, limit]
 
+    AdvisorRequestList:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdvisorRequest"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+      required: [data, total, page, limit]
+    
     Error:
       type: object
       properties:

--- a/docs/api/api-specs/process5.1.yaml
+++ b/docs/api/api-specs/process5.1.yaml
@@ -1,19 +1,22 @@
 openapi: 3.0.3
 info:
   title: Senior App — Process 5 Committee Assignment
-  version: 1.0.0
-  contact:
-    name: Backend Service Layer
+  version: 1.3.1
   description: |
     Committee lifecycle and member assignments (docs/system-processes.md — Process 5).
     Rules: no committee type on API; no PATCH for rename/retype; advisor links have no assignment source;
-    remove group with DELETE on /groups and groupId in JSON body.
+    remove group with DELETE /committees/{committeeId}/groups/{groupId} using path parameter.
     Nested assignment objects omit committeeId in responses (context from path or parent Committee.id).
 
     Cross-service dependency: This service relies on the Advisor Assignment API (Process 4)
     for schedule window management. Specifically, POST /committees/{committeeId}/groups returns
     423 Locked when the assignment window is closed — callers should query
     GET /schedules/active on the Advisor Assignment API to check window status.
+
+    Authorization policy: canonical role names are uppercase
+    (COORDINATOR, TEAM_LEADER, ADVISOR, ADMIN, STUDENT).
+    [ANY] means any authenticated role with a valid JWT.
+    Schedule ownership is in Process 4; this API does not define a local POST /schedules endpoint.
 
 servers:
   - url: http://localhost:3000
@@ -32,6 +35,90 @@ tags:
     description: Per-advisor grading scope within a committee (which groups each advisor is responsible for grading)
 
 paths:
+  # ─────────────────────────────────────────────
+  # Schedule Management
+  # ─────────────────────────────────────────────
+  /schedules:
+    post:
+      tags: [schedule]
+      summary: Set a schedule window for a specific phase
+      operationId: setSchedule
+      security:
+        - BearerAuth: []
+      description: |
+        **Requires Role:** [COORDINATOR]
+
+        Sets the schedule window (start and end dates) for a specific system phase 
+        (e.g., ADVISOR_SELECTION or COMMITTEE_ASSIGNMENT).
+        
+        **Preconditions (_requires_):**
+        - The `endDatetime` MUST be strictly after the `startDatetime`.
+        - Caller must have the COORDINATOR role.
+        
+        **Postconditions (_effects_):**
+        - The new schedule is persisted in the Database.
+        - Any previously active schedule for this specific `phase` is overridden or marked as historical.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetScheduleRequest"
+      responses:
+        "201":
+          description: Schedule created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Schedule"
+        "400":
+          description: Bad Request – e.g., end date is before start date.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Forbidden – Caller does not have the COORDINATOR role.
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /schedules/active:
+    get:
+      tags: [schedule]
+      summary: Get the currently active schedule window for a phase
+      operationId: getActiveSchedule
+      security:
+        - BearerAuth: []
+      description: |
+        **Requires Role:** [ANY AUTHENTICATED USER]
+
+        Returns the currently active schedule window for the requested phase.
+        This is a convenience endpoint so clients don't have to fetch all historical schedules.
+        
+        - Team Leaders use `?phase=ADVISOR_SELECTION` before sending advisor requests.
+        - Coordinators use `?phase=COMMITTEE_ASSIGNMENT` before assigning groups to committees.
+      parameters:
+        - name: phase
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [ADVISOR_SELECTION, COMMITTEE_ASSIGNMENT]
+          description: Specify which schedule phase you are querying.
+      responses:
+        "200":
+          description: The active schedule window for the requested phase
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActiveSchedule"
+        "400":
+          description: Bad Request – Phase parameter is missing or invalid.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Not Found – No active schedule window currently exists for this phase.
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   # ─────────────────────────────────────────────
   # 5.1 Committees – CRUD
   # ─────────────────────────────────────────────
@@ -73,13 +160,18 @@ paths:
                 $ref: "#/components/schemas/CommitteePage"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
 
     post:
       tags: [committees]
       summary: Create committee
-      description: Creates a committee with a display name only (no committee type in this API).
+      description: |
+        **Requires Role:** [COORDINATOR]
+
+        Creates a committee.
       operationId: createCommittee
       security:
         - BearerAuth: []
@@ -126,6 +218,8 @@ paths:
                 $ref: "#/components/schemas/Committee"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -133,16 +227,30 @@ paths:
 
     delete:
       tags: [committees]
-      summary: Delete committee
-      description: Removes the committee. Cascading deletion of assignments depends on implementation and business rules.
+      summary: Delete a committee
       operationId: deleteCommittee
       security:
         - BearerAuth: []
+      description: |
+        **Requires Role:** [COORDINATOR]
+
+        Deletes a committee entity.
+        
+        **Postconditions (_effects_ - Cascade Rules):**
+        - The Committee record is deleted.
+        - ALL `Advisor-Committee` link records are permanently deleted.
+        - ALL `Group-Committee` link records are permanently deleted. 
+        - **Crucial:** The actual Advisor and Group entities are NOT deleted. Groups are simply returned to the pool of groups needing committee assignment.
       parameters:
-        - $ref: "#/components/parameters/CommitteeId"
+        - name: committeeId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "204":
-          description: Committee deleted; no response body
+          description: Committee and all associated assignment links successfully deleted.
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -157,7 +265,7 @@ paths:
     patch:
       tags: [committees]
       summary: Update committee details
-      description: Updates committee metadata (e.g., fixing a typo in the name). Does not affect assignments.
+      description: Updates committee metadata (e.g., fixing a typo in the name). Does not affect assignments. Only Coordinators may perform this action.
       operationId: updateCommittee
       security:
         - BearerAuth: []
@@ -168,13 +276,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                  maxLength: 200
-                  description: The corrected display name
+              $ref: "#/components/schemas/CommitteeUpdate"
       responses:
         "200":
           description: Committee updated successfully
@@ -193,30 +295,44 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  # ─────────────────────────────────────────────
-  # 5.2 Jury Members
-  # ─────────────────────────────────────────────
   /committees/{committeeId}/jury-members:
     get:
       tags: [committee-jury]
       summary: List jury members
-      description: Returns assignments for this committee. Each item has userId and assignedAt only (no committeeId).
+      description: Returns paginated jury assignments for this committee. Each item has userId and assignedAt only (no committeeId).
       operationId: listJuryMembers
       security:
         - BearerAuth: []
       parameters:
         - $ref: "#/components/parameters/CommitteeId"
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: 1-based page index
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          description: Page size
       responses:
         "200":
-          description: List of jury assignments
+          description: Paginated list of jury assignments
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/JuryMemberResponse"
+                $ref: "#/components/schemas/JuryMemberPage"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -282,30 +398,44 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  # ─────────────────────────────────────────────
-  # 5.3 Committee Advisors
-  # ─────────────────────────────────────────────
   /committees/{committeeId}/advisors:
     get:
       tags: [committee-advisors]
       summary: List committee advisors
-      description: Returns advisor links with advisorUserId and assignedAt only (no assignment source in this API).
+      description: Returns paginated advisor links for this committee. Each item has advisorUserId and assignedAt only (no assignment source).
       operationId: listCommitteeAdvisors
       security:
         - BearerAuth: []
       parameters:
         - $ref: "#/components/parameters/CommitteeId"
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: 1-based page index
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          description: Page size
       responses:
         "200":
-          description: List of advisor assignments
+          description: Paginated list of advisor assignments
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/CommitteeAdvisorResponse"
+                $ref: "#/components/schemas/CommitteeAdvisorPage"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -313,24 +443,37 @@ paths:
 
     post:
       tags: [committee-advisors]
-      summary: Link advisor to committee
-      description: |
-        Links an advisor to a committee. Only Coordinators may perform this action.
-        If assignedAt is omitted, server may default to now.
+      summary: Assign an advisor to a committee
       operationId: addCommitteeAdvisor
       security:
         - BearerAuth: []
+      description: |
+        **Requires Role:** [COORDINATOR]
+
+        Adds an advisor to a committee.
+        
+        **Preconditions (_requires_):**
+        - The Committee Assignment schedule window MUST be active.
+        
+        **Postconditions (_effects_):**
+        - Creates a link record with the specified `assignmentSource`.
+        - Triggers an internal notification to the assigned Advisor indicating their jury duties.
       parameters:
-        - $ref: "#/components/parameters/CommitteeId"
+        - name: committeeId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CommitteeAdvisorInvite"
+              $ref: "#/components/schemas/AssignAdvisorRequest"
       responses:
         "201":
-          description: Advisor linked
+          description: Advisor successfully assigned to committee
           content:
             application/json:
               schema:
@@ -364,6 +507,7 @@ paths:
           description: User id of the advisor to remove
           schema:
             type: string
+            format: uuid
       responses:
         "204":
           description: Removed; no response body
@@ -376,30 +520,44 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  # ─────────────────────────────────────────────
-  # 5.4 Committee Groups
-  # ─────────────────────────────────────────────
   /committees/{committeeId}/groups:
     get:
       tags: [committee-groups]
       summary: List assigned groups
-      description: Returns groupId and assignedAt per row (no committeeId on each item).
+      description: Returns paginated group assignments for this committee. Each item has groupId and assignedAt only (no committeeId).
       operationId: listCommitteeGroups
       security:
         - BearerAuth: []
       parameters:
         - $ref: "#/components/parameters/CommitteeId"
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: 1-based page index
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          description: Page size
       responses:
         "200":
-          description: List of group assignments
+          description: Paginated list of group assignments
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/CommitteeGroupResponse"
+                $ref: "#/components/schemas/CommitteeGroupPage"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -408,17 +566,22 @@ paths:
     post:
       tags: [committee-groups]
       summary: Assign group to committee
-      description: |
-        Assigns a group to this committee. Only Coordinators may perform this action.
-        Prerequisites (per project definition):
-          1. The group must have completed Group Creation.
-          2. The group must have completed Group-Advisor Association (i.e. have an assigned advisor).
-        This action is also bounded by a schedule window set by the Coordinator — returns 423
-        if the assignment window is not currently open.
-        If assignedAt is omitted, server may default to now.
       operationId: assignGroupToCommittee
       security:
         - BearerAuth: []
+      description: |
+        **Requires Role:** [COORDINATOR]
+
+        Assigns a group to this committee.
+        
+        **Preconditions (_requires_):**
+        1. The group must have completed Group Creation.
+        2. The group must have completed Group-Advisor Association (i.e., have an assigned advisor).
+        3. The Committee Assignment schedule window MUST be open.
+        
+        **Postconditions (_effects_):**
+        - Group is successfully linked to the committee.
+        - **Auto-Link:** The system automatically identifies the group's Primary Advisor (established in Process 4) and silently adds them to this Committee's advisor list, if they are not already present.
       parameters:
         - $ref: "#/components/parameters/CommitteeId"
       requestBody:
@@ -429,7 +592,7 @@ paths:
               $ref: "#/components/schemas/CommitteeGroupInvite"
       responses:
         "201":
-          description: Group assigned
+          description: Group assigned successfully. Primary advisor auto-linked if applicable.
           content:
             application/json:
               schema:
@@ -439,11 +602,11 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Forbidden – Caller does not have the COORDINATOR role.
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Group is already assigned to a committee
+          description: Conflict – Group is already assigned to a committee.
         "422":
           description: |
             Unprocessable — prerequisite not met. The group does not have a confirmed
@@ -487,6 +650,38 @@ paths:
           $ref: "#/components/responses/InternalError"
 
   # ─────────────────────────────────────────────
+  # 5.5 Reverse Lookup: Group's Committee
+  # ─────────────────────────────────────────────
+  /groups/{groupId}/committee:
+    get:
+      tags: [groups, committees]
+      summary: Get the committee assigned to a specific group
+      operationId: getGroupCommittee
+      security:
+        - BearerAuth: []
+      description: |
+        **Requires Role:** [ANY]
+
+        Returns the committee details that a specific group has been assigned to. 
+        Used by Team Leaders and Students to see their jury members.
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The committee assigned to this group
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Committee" # Assuming you have a basic Committee schema
+        "404":
+          description: Group not found, or Group is not currently assigned to any committee.
+
+  # ─────────────────────────────────────────────
   # Per-advisor grading scope within a committee
   # ─────────────────────────────────────────────
   /committees/{committeeId}/advisors/{advisorUserId}/groups:
@@ -494,7 +689,9 @@ paths:
       tags: [committee-grading-scope]
       summary: List groups an advisor is responsible for grading in this committee
       description: |
-        Returns the set of groups this advisor must grade within the committee.
+        **Requires Role:** [COORDINATOR, ADVISOR]
+
+        Returns the paginated set of groups this advisor must grade within the committee.
         Per project definition, each advisor in a committee grades their own
         groups AND the groups of other advisors in the same committee.
         This endpoint exposes the resolved grading scope so the system and UI
@@ -510,15 +707,31 @@ paths:
           description: User ID of the advisor whose grading scope is being queried
           schema:
             type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: 1-based page index
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          description: Page size
       responses:
         "200":
-          description: List of groups this advisor is responsible for grading
+          description: Paginated list of groups this advisor is responsible for grading
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/AdvisorGradingScopeItem"
+                $ref: "#/components/schemas/AdvisorGradingScopePage"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -541,10 +754,9 @@ components:
       name: committeeId
       in: path
       required: true
-      description: Committee primary key (UUID)
+      description: Committee primary key (e.g. MongoDB ObjectId as string)
       schema:
         type: string
-        format: uuid
     UserId:
       name: userId
       in: path
@@ -552,7 +764,6 @@ components:
       description: User primary key for jury removal
       schema:
         type: string
-        format: uuid
 
   responses:
     BadRequest:
@@ -560,44 +771,33 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ErrorBody"
     Unauthorized:
       description: Missing or invalid JWT
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
     Forbidden:
       description: Authenticated but insufficient permissions
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
     NotFound:
       description: Committee or related resource not found
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
     InternalError:
       description: Unexpected server error
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ErrorBody"
 
   schemas:
-    Error:
+    ErrorBody:
       type: object
-      description: Standard error payload
-      required: [code, message]
+      description: Typical NestJS-style error payload (shape may vary)
       properties:
-        code:
-          type: string
-          description: Machine-readable error code
+        statusCode:
+          type: integer
+          example: 400
         message:
           type: string
-          description: Human-readable error description
+        error:
+          type: string
+          example: Bad Request
 
     CommitteeCreate:
       type: object
@@ -617,7 +817,6 @@ components:
       properties:
         id:
           type: string
-          format: uuid
           description: Committee id
         name:
           type: string
@@ -627,7 +826,7 @@ components:
         updatedAt:
           type: string
           format: date-time
-          description: Present if updates occur (e.g. name change via future API)
+          description: Timestamp of the last update to this committee, if any updates have occurred.
         jury:
           type: array
           description: Optional embed; may be omitted in list responses to reduce payload
@@ -642,11 +841,21 @@ components:
           items:
             $ref: "#/components/schemas/CommitteeGroupResponse"
 
+    CommitteeUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: Updated display name of the committee
+      minProperties: 1
+
     CommitteePage:
       type: object
-      required: [items, total, page, limit]
+      required: [data, total, page, limit]
       properties:
-        items:
+        data:
           type: array
           items:
             $ref: "#/components/schemas/Committee"
@@ -665,10 +874,11 @@ components:
         userId:
           type: string
           format: uuid
+          description: ID of the user to assign as jury member
         assignedAt:
           type: string
           format: date-time
-          description: Optional; server may default to current time
+          description: Optional; server may default to current time. assignedByUserId is derived from JWT — do not send in body.
 
     JuryMemberResponse:
       type: object
@@ -683,36 +893,23 @@ components:
           format: date-time
         assignedByUserId:
           type: string
-          format: uuid
           description: ID of the user (e.g., Coordinator) who made this assignment
-
-    CommitteeAdvisorInvite:
-      type: object
-      required: [advisorUserId]
-      properties:
-        advisorUserId:
-          type: string
-          format: uuid
-        assignedAt:
-          type: string
-          format: date-time
-          description: Optional; server may default to current time
 
     CommitteeAdvisorResponse:
       type: object
-      required: [advisorUserId, assignedAt, assignedByUserId]
-      description: Advisor link without committeeId or assignment source
       properties:
-        advisorUserId:
+        committeeId:
           type: string
           format: uuid
+        advisorId:
+          type: string
+          format: uuid
+        assignmentSource:
+          type: string
+          enum: [PRIMARY_ADVISOR, JURY_MEMBER]
         assignedAt:
           type: string
           format: date-time
-        assignedByUserId:
-          type: string
-          format: uuid
-          description: ID of the user who made this assignment
 
     CommitteeGroupInvite:
       type: object
@@ -720,11 +917,10 @@ components:
       properties:
         groupId:
           type: string
-          format: uuid
         assignedAt:
           type: string
           format: date-time
-          description: Optional; server may default to current time
+          description: Optional; server may default to current time. assignedByUserId is derived from JWT — do not send in body.
 
     CommitteeGroupResponse:
       type: object
@@ -733,14 +929,26 @@ components:
       properties:
         groupId:
           type: string
-          format: uuid
         assignedAt:
           type: string
           format: date-time
         assignedByUserId:
           type: string
-          format: uuid
           description: ID of the user who made this assignment
+
+    AssignAdvisorRequest:
+      type: object
+      properties:
+        advisorId:
+          type: string
+          format: uuid
+          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        assignmentSource:
+          type: string
+          enum: [PRIMARY_ADVISOR, JURY_MEMBER]
+          description: Indicates if they are auto-assigned via their group, or manually added as a jury member.
+          example: "JURY_MEMBER"
+      required: [advisorId, assignmentSource]
 
     AdvisorGradingScopeItem:
       type: object
@@ -752,7 +960,6 @@ components:
       properties:
         groupId:
           type: string
-          format: uuid
           description: ID of the group this advisor must grade
         assignedAt:
           type: string
@@ -766,9 +973,137 @@ components:
             that this advisor must also grade per committee rules).
         originalAdvisorUserId:
           type: string
-          format: uuid
           nullable: true
           description: The advisor who owns this group (null if isOwnGroup is true)
+    
+    JuryMemberPage:
+      type: object
+      required: [data, total, page, limit]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/JuryMemberResponse"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
 
+    CommitteeAdvisorPage:
+      type: object
+      required: [data, total, page, limit]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/CommitteeAdvisorResponse"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+
+    CommitteeGroupPage:
+      type: object
+      required: [data, total, page, limit]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/CommitteeGroupResponse"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+
+    AdvisorGradingScopePage:
+      type: object
+      required: [data, total, page, limit]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdvisorGradingScopeItem"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+
+    SetScheduleRequest:
+      type: object
+      properties:
+        startDatetime:
+          type: string
+          format: date-time
+          description: Schedule window start
+        endDatetime:
+          type: string
+          format: date-time
+          description: Schedule window end
+        phase:
+          type: string
+          enum: [ADVISOR_SELECTION, COMMITTEE_ASSIGNMENT]
+          description: Indicates which process this schedule applies to.
+          example: "COMMITTEE_ASSIGNMENT"
+      required: [startDatetime, endDatetime, phase]
+
+    Schedule:
+      type: object
+      properties:
+        scheduleId:
+          type: string
+          format: uuid
+        coordinatorId:
+          type: string
+          format: uuid
+        startDatetime:
+          type: string
+          format: date-time
+        endDatetime:
+          type: string
+          format: date-time
+        phase:
+          type: string
+          enum: [ADVISOR_SELECTION, COMMITTEE_ASSIGNMENT]
+          description: The specific project phase this schedule dictates.
+        createdAt:
+          type: string
+          format: date-time
+      required: [scheduleId, coordinatorId, startDatetime, endDatetime, phase]
+
+    ActiveSchedule:
+      type: object
+      description: The currently active schedule window for a specific phase.
+      properties:
+        scheduleId:
+          type: string
+          format: uuid
+        coordinatorId:
+          type: string
+          format: uuid
+        startDatetime:
+          type: string
+          format: date-time
+        endDatetime:
+          type: string
+          format: date-time
+        phase:
+          type: string
+          enum: [ADVISOR_SELECTION, COMMITTEE_ASSIGNMENT]
+        isOpen:
+          type: boolean
+          description: True if the current server time falls within the start/end window
+        createdAt:
+          type: string
+          format: date-time
+      required: [scheduleId, startDatetime, endDatetime, phase, isOpen]
+      
 security:
   - BearerAuth: []


### PR DESCRIPTION
Unifies and extends Process 4 and Process 5 OpenAPI specs: adds canonical role names and role-based requirements, introduces schedule phase handling, and improves pagination and error shapes.

Highlights:
- Add global Authorization policy note and require explicit roles for endpoints.
- Introduce schedule endpoints and phase awareness (startDatetime/endDatetime/phase) and require clients to query /schedules/active?phase=...
- Process 4: change /advisors to require COORDINATOR/TEAM_LEADER and return PaginatedAdvisors; require ADVISOR role naming; add 403 responses.
- Replace withdraw DELETE with PATCH /requests/{requestId} to update request status (preserves history) and add UpdateRequestStatus schema.
- Change release endpoint to DELETE /advisors/{advisorId}/groups/{groupId}; change transfer endpoint to PATCH /groups/{groupId}/advisor; disband now DELETE /groups/{groupId} and move GET /groups/{groupId}/status to return assignment status.
- Replace several object schemas (GroupStatus -> GroupAssignmentStatus), add Paginated/List wrappers (AdvisorRequestList, PaginatedAdvisors, etc.), and add examples/required fields for schedules and advisor objects.
- Process 5: bump version to 1.3.1, add same Authorization policy, add schedule endpoints, add pagination to committee/list endpoints, require Coordinator role for mutating actions, add reverse lookup GET /groups/{groupId}/committee, and introduce new request/response page schemas.
- Normalize error payload to ErrorBody, adjust parameter shapes (committeeId/userId descriptions), and adjust many response codes/descriptions.

These edits include breaking/behavioral changes (new required query param 'phase', HTTP method/path changes, renamed/required schema fields, and stricter role checks) and thus should be reviewed before deployment.