### PR TITLE
feat(backend): implement SOW validation logic (Issue #64)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,6 +40,7 @@
         "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
+        "@types/multer": "^2.1.0",
         "@types/node": "^22.10.7",
         "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.2",
@@ -234,6 +235,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2142,6 +2144,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2189,6 +2192,7 @@
       "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2284,6 +2288,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
       "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2586,6 +2591,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2709,11 +2715,22 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2899,6 +2916,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3606,6 +3624,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3655,6 +3674,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3920,6 +3940,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4184,6 +4205,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4470,13 +4492,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5394,6 +5418,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5454,6 +5479,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7010,6 +7036,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8560,6 +8587,7 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.3.3.tgz",
       "integrity": "sha512-sfv5LOIPWeN5o/281kp4Rx9ZnuXb0g8CtvBTi7trYQs2PYYx8LWXegXxG3ar7VEns1o+d4h9LI/Dtc7dTTyYmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "kareem": "3.2.0",
         "mongodb": "~7.1",
@@ -9000,6 +9028,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9245,6 +9274,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9439,7 +9469,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/repeating": {
       "version": "2.0.1",
@@ -9649,6 +9680,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10488,6 +10520,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10863,6 +10896,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11045,6 +11079,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11411,6 +11446,7 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11480,6 +11516,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,7 @@
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
+    "@types/multer": "^2.1.0",
     "@types/node": "^22.10.7",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { TeamsModule } from './teams/teams.module';
 import { AdminModule } from './admin/admin.module';
 import { GroupsModule } from './groups/groups.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { SubmissionsModule } from './submissions/submissions.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { NotificationsModule } from './notifications/notifications.module';
     AdminModule,
     GroupsModule,
     NotificationsModule,
+    SubmissionsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/groups/groups.controller.ts
+++ b/backend/src/groups/groups.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus, Get, Param } from '@nestjs/common';
 import { GroupsService } from './groups.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 
@@ -10,5 +10,10 @@ export class GroupsController {
   @HttpCode(HttpStatus.CREATED)
   async createGroup(@Body() createGroupDto: CreateGroupDto) {
     return this.groupsService.createGroup(createGroupDto);
+  }
+
+  @Get(':groupId/validate-statement-of-work')
+  async validateSow(@Param('groupId') groupId: string) {
+    return this.groupsService.validateStatementOfWork(groupId);
   }
 }

--- a/backend/src/groups/groups.module.ts
+++ b/backend/src/groups/groups.module.ts
@@ -3,10 +3,12 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { GroupsController } from './groups.controller';
 import { GroupsService } from './groups.service';
 import { Group, GroupSchema } from './group.entity';
+import { Submission, SubmissionSchema } from '../submissions/schemas/submission.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Group.name, schema: GroupSchema }]),
+    MongooseModule.forFeature([{ name: Submission.name, schema: SubmissionSchema }])
   ],
   controllers: [GroupsController],
   providers: [GroupsService],

--- a/backend/src/groups/groups.service.ts
+++ b/backend/src/groups/groups.service.ts
@@ -1,13 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Group, GroupDocument, GroupStatus } from './group.entity';
 import { CreateGroupDto } from './dto/create-group.dto';
+import { Submission } from '../submissions/schemas/submission.schema';
 
 @Injectable()
 export class GroupsService {
   constructor(
     @InjectModel(Group.name) private groupModel: Model<GroupDocument>,
+    @InjectModel(Submission.name) private submissionModel: Model<Submission>,
   ) {}
 
   async createGroup(createGroupDto: CreateGroupDto): Promise<Group> {
@@ -21,5 +23,42 @@ export class GroupsService {
 
   async findGroupById(groupId: string): Promise<Group | null> {
     return this.groupModel.findOne({ groupId }).exec();
+  }
+
+  async validateStatementOfWork(groupId: string) {
+    const submissions = await this.submissionModel.find({ 
+      groupId: groupId,
+      type: { $in: ['SOW', 'RevisedProposal'] }
+    });
+
+    if (!submissions || submissions.length === 0) {
+      throw new NotFoundException(`No submission records found for group ID: ${groupId}`);
+    }
+
+    const sow = submissions.find(sub => sub.type === 'SOW');
+    const revisedProposal = submissions.find(sub => sub.type === 'RevisedProposal');
+
+    const sowStatus = sow ? sow.status : 'Not Submitted';
+    const revisedStatus = revisedProposal ? revisedProposal.status : 'Not Required';
+
+    let validationState = 'Pending';
+
+    if (sowStatus === 'Approved' && (revisedStatus === 'Approved' || revisedStatus === 'Not Required')) {
+      validationState = 'Approved';
+    } else if (sowStatus === 'Needs Revision' || revisedStatus === 'Needs Revision') {
+      validationState = 'Needs Revision';
+    } else if (sowStatus === 'Submitted' || revisedStatus === 'Submitted') {
+      validationState = 'Submitted';
+    }
+
+    return {
+      groupId,
+      documents: {
+        statementOfWork: sowStatus,
+        revisedProposal: revisedStatus,
+      },
+      overallValidationStatus: validationState,
+      canClearSowStatus: validationState === 'Approved'
+    };
   }
 }

--- a/backend/src/submissions/schemas/submission.schema.ts
+++ b/backend/src/submissions/schemas/submission.schema.ts
@@ -9,6 +9,13 @@ export class Submission extends Document {
   @Prop({ default: 'Pending' })
   status!: string;
 
+
+  @Prop({ required: true })
+  groupId!: string;
+
+  @Prop({ required: true })
+  type!: string;
+
   //Array to hold metadata of documents
   @Prop([{
     originalName: { type: String, required: true },

--- a/backend/src/submissions/schemas/submission.schema.ts
+++ b/backend/src/submissions/schemas/submission.schema.ts
@@ -1,0 +1,25 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Submission extends Document {
+  @Prop({ required: true })
+  title!: string;
+
+  @Prop({ default: 'Pending' })
+  status!: string;
+
+  //Array to hold metadata of documents
+  @Prop([{
+    originalName: { type: String, required: true },
+    mimeType: { type: String, required: true },
+    uploadedAt: { type: Date, default: Date.now }
+  }])
+  documents!: Array<{
+    originalName: string;
+    mimeType: string;
+    uploadedAt: Date;
+  }>;
+}
+
+export const SubmissionSchema = SchemaFactory.createForClass(Submission);

--- a/backend/src/submissions/submissions.controller.spec.ts
+++ b/backend/src/submissions/submissions.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SubmissionsController } from './submissions.controller';
+
+describe('SubmissionsController', () => {
+  let controller: SubmissionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SubmissionsController],
+    }).compile();
+
+    controller = module.get<SubmissionsController>(SubmissionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/submissions/submissions.controller.ts
+++ b/backend/src/submissions/submissions.controller.ts
@@ -1,0 +1,39 @@
+import 'multer';
+import { 
+  Controller, 
+  Post, 
+  Get,
+  Param, 
+  UploadedFile, 
+  UseInterceptors, 
+  BadRequestException 
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { SubmissionsService } from './submissions.service';
+
+@Controller('submissions')
+export class SubmissionsController {
+  constructor(private readonly submissionsService: SubmissionsService) {}
+
+  @Post(':submissionId/documents')
+  @UseInterceptors(FileInterceptor('file', {
+    fileFilter: (req, file, callback) => {
+      if (!file.originalname.match(/\.(pdf|doc|docx|png|jpg|jpeg)$/)) {
+        return callback(new BadRequestException('Only PDF, Word, and Image files are allowed!'), false);
+      }
+      callback(null, true);
+    },
+    limits: { fileSize: 5 * 1024 * 1024 } // Max 5MB
+  }))
+  async uploadFile(
+    @Param('submissionId') submissionId: string, 
+    @UploadedFile() file: Express.Multer.File
+  ) {
+    
+    if (!file) {
+      throw new BadRequestException('File is required or invalid file type.');
+    }
+
+    return this.submissionsService.uploadDocument(submissionId, file);
+  }
+}

--- a/backend/src/submissions/submissions.module.ts
+++ b/backend/src/submissions/submissions.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { SubmissionsService } from './submissions.service';
+import { SubmissionsController } from './submissions.controller';
+import { Submission, SubmissionSchema } from './schemas/submission.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Submission.name, schema: SubmissionSchema }])
+  ],
+  providers: [SubmissionsService],
+  controllers: [SubmissionsController]
+})
+export class SubmissionsModule {}

--- a/backend/src/submissions/submissions.service.spec.ts
+++ b/backend/src/submissions/submissions.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SubmissionsService } from './submissions.service';
+
+describe('SubmissionsService', () => {
+  let service: SubmissionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SubmissionsService],
+    }).compile();
+
+    service = module.get<SubmissionsService>(SubmissionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/submissions/submissions.service.ts
+++ b/backend/src/submissions/submissions.service.ts
@@ -1,0 +1,38 @@
+import 'multer';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Submission } from './schemas/submission.schema';
+
+@Injectable()
+export class SubmissionsService {
+  constructor(
+    @InjectModel(Submission.name) private submissionModel: Model<Submission>,
+  ) {}
+
+  async uploadDocument(submissionId: string, file: Express.Multer.File) {
+    // 1. Find the Submission from the database (If not, throw 404)
+    const submission = await this.submissionModel.findById(submissionId);
+    if (!submission) {
+      throw new NotFoundException(`Submission with ID ${submissionId} not found.`);
+    }
+
+    // 2. Prepare file information (metadata)
+    const newDocument = {
+      originalName: file.originalname,
+      mimeType: file.mimetype,
+      uploadedAt: new Date(),
+    };
+
+    // 3. Add the file to the record and update the database
+    submission.documents = submission.documents || [];
+    submission.documents.push(newDocument);
+    await submission.save();
+
+    return {
+      message: 'Document uploaded and linked successfully',
+      document: newDocument,
+    };
+  }
+
+}


### PR DESCRIPTION
### 1. PR Type:
Feature: Adds SOW and Revised Proposal validation logic.

### 2. Purpose & Description
**Problem Statement:**
The system needs to evaluate a group's documentation state to determine if their Statement of Work (SOW) is fully approved, taking into account any dependency on a Revised Proposal.

**Changes Made:**
* Updated `SubmissionSchema` to include `groupId` and `type` fields.
* Imported `SubmissionSchema` into the existing `GroupsModule`.
* Implemented `validateStatementOfWork` in `GroupsService` to aggregate document statuses and apply dependency rules.
* Created the `GET /groups/{groupId}/validate-statement-of-work` endpoint in `GroupsController`.

**Related Issue:** Closes #64

### 3. Testing & Verification
**What Was Tested:**
* Tested database queries filtering by `groupId` and `type`.
* Verified the dependency logic (SOW cannot clear if Revised Proposal is Pending).
* Verified the `404 Not Found` response for invalid/empty groups.

**Verification Steps:**
1. Added mock SOW ("Approved") and RevisedProposal ("Pending") to the database via MongoDB Compass.
2. Hit the endpoint `GET /groups/TEST-GRUP-1/validate-statement-of-work`.
3. Verified the response correctly returned `overallValidationStatus: "Pending"` and `canClearSowStatus: false`.

### 4. Strict Checklist
- [x] My PR targets the `main` branch.
- [x] I have updated related API/System documentation if applicable.
- [x] I have kept the changes strictly focused on the stated purpose.

### 5. Executive Summary
**Summary:**
This PR implements the business logic required for the Student Dashboard's SOW status banner. It introduces a new endpoint that safely checks a specific group's documents, evaluates the status of both the SOW and any required Revised Proposals, and strictly dictates whether the system should clear the SOW dependency.