### PR TITLE
bug: Fix api url registration network error

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -10,6 +10,7 @@ async function bootstrap() {
     origin: process.env.CORS_ORIGIN as string,
     credentials: true,
   });
+  app.setGlobalPrefix('api/v1');
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.use(helmet());
   app.use(bodyParser.json());

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Frontend API Configuration
+VITE_API_BASE_URL=http://localhost:3001/api/v1

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -2,7 +2,7 @@
  * API configuration for the application
  */
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api/v1';
 
 export const apiConfig = {
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## 1. PR Type
- [x] Bug Fix: Resolves an identified issue or bug.

## 2. Purpose & Description
**Problem Statement:**
Frontend registration requests were failing with `net::ERR_CONNECTION_REFUSED` when attempting to POST to the registration endpoint. The issue had two root causes: (1) Frontend was configured to call the wrong port (8080 instead of 3001), and (2) Backend did not have the `/api/v1` global prefix configured, causing route mismatch between frontend expectations and backend actual routes.

**Changes Made:**
- **Frontend (`frontend/src/config/api.js`):**
  - Changed default `API_BASE_URL` from `http://localhost:8080/api/v1` to `http://localhost:3001/api/v1`
  - Supports environment variable override via `VITE_API_BASE_URL`
  
- **Frontend (new files):**
  - Created `frontend/.env.local` with `VITE_API_BASE_URL=http://localhost:3001/api/v1` for local development
  - Created `frontend/.env.example` to document required environment configuration

- **Backend (`backend/src/main.ts`):**
  - Added `app.setGlobalPrefix('api/v1')` to configure global API prefix
  - All backend routes now accessible under `/api/v1` namespace
  - Routes previously at `/auth/register` now at `/api/v1/auth/register`

**Related Issue:** Closes #86

## 3. Testing & Verification
**What Was Tested:**
- Frontend registration endpoint now calls correct backend URL on port 3001
- Backend accepts requests at `/api/v1/auth/register` endpoint
- Request routing properly configured end-to-end

**Verification Steps (How to test):**
1. Ensure backend is running: `npm run start:dev` in `backend/` folder
2. Ensure frontend is running: `npm run dev` in `frontend/` folder
3. Open `http://localhost:5173/register` in browser
4. Fill in registration form with:
   - Email: `test@example.com`
   - Password: `TestPassword123`
   - Confirm Password: `TestPassword123`
5. Click "Create Account"
6. Check browser Network tab - request should go to `http://localhost:3001/api/v1/auth/register`
7. Request should succeed (or fail with validation error, not connection error)
8. Check browser console - no `net::ERR_CONNECTION_REFUSED` should appear

**Proof of Verification:**
- **Frontend/UI:** Network request successfully reaches backend endpoint at correct URL/port. Registration form submission no longer shows "Connection Refused" errors.
- **Backend:** Routes properly prefixed with `/api/v1`. All auth endpoints accessible under new namespace (e.g., `/api/v1/auth/register`, `/api/v1/auth/login`).

## 4. Strict Checklist
- [x] My PR targets the `main` branch.
- [x] I have updated related API/System documentation if applicable (created `.env.example` file documenting configuration).
- [x] I have kept the changes strictly focused on the stated purpose (URL configuration and API prefix routing only).

## 5. Executive Summary
**Summary:**
Fixed registration network errors by correcting frontend API base URL (8080 → 3001) and adding missing global `/api/v1` prefix to backend routes. Frontend now properly reaches backend at `http://localhost:3001/api/v1/auth/register` instead of failing with connection refused errors on incorrect port.