### PR TITLE
feat(schedules): implement POST /schedules and GET /schedules/active …

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -237,7 +237,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2152,7 +2151,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2200,7 +2198,6 @@
       "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2296,7 +2293,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
       "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2645,7 +2641,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2784,7 +2779,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2970,7 +2964,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3678,7 +3671,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3728,7 +3720,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3993,7 +3984,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4258,7 +4248,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4545,15 +4534,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5471,7 +5458,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5532,7 +5518,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7089,7 +7074,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8639,7 +8623,6 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.3.3.tgz",
       "integrity": "sha512-sfv5LOIPWeN5o/281kp4Rx9ZnuXb0g8CtvBTi7trYQs2PYYx8LWXegXxG3ar7VEns1o+d4h9LI/Dtc7dTTyYmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "kareem": "3.2.0",
         "mongodb": "~7.1",
@@ -9080,7 +9063,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9326,7 +9308,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9521,8 +9502,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/repeating": {
       "version": "2.0.1",
@@ -9732,7 +9712,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10596,7 +10575,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10972,7 +10950,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11155,7 +11132,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11522,7 +11498,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11592,7 +11567,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { GroupsModule } from './groups/groups.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { PhasesModule } from './phases/phases.module';
 import { SubmissionsModule } from './submissions/submissions.module';
+import { SchedulesModule } from './schedules/schedules.module';
 
 
 @Module({
@@ -25,6 +26,7 @@ import { SubmissionsModule } from './submissions/submissions.module';
     NotificationsModule,
     PhasesModule,
     SubmissionsModule,
+    SchedulesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/schedules/dto/set-schedule.dto.ts
+++ b/backend/src/schedules/dto/set-schedule.dto.ts
@@ -1,0 +1,20 @@
+import { IsDateString, IsEnum, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { SchedulePhase } from '../schedule.schema';
+
+export class SetScheduleDto {
+  @ApiProperty({ enum: SchedulePhase, enumName: 'SchedulePhase' })
+  @IsEnum(SchedulePhase)
+  @IsNotEmpty()
+  phase!: SchedulePhase;
+
+  @ApiProperty({ description: 'Schedule window start (ISO 8601 date-time)' })
+  @IsDateString()
+  @IsNotEmpty()
+  startDatetime!: string;
+
+  @ApiProperty({ description: 'Schedule window end (ISO 8601 date-time)' })
+  @IsDateString()
+  @IsNotEmpty()
+  endDatetime!: string;
+}

--- a/backend/src/schedules/schedule.schema.ts
+++ b/backend/src/schedules/schedule.schema.ts
@@ -1,0 +1,33 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+import { randomUUID } from 'crypto';
+
+export type ScheduleDocument = HydratedDocument<Schedule>;
+
+export enum SchedulePhase {
+  ADVISOR_SELECTION = 'ADVISOR_SELECTION',
+  COMMITTEE_ASSIGNMENT = 'COMMITTEE_ASSIGNMENT',
+}
+
+@Schema({ timestamps: true })
+export class Schedule {
+  @Prop({ type: String, default: () => randomUUID(), unique: true })
+  scheduleId!: string;
+
+  @Prop({ required: true })
+  coordinatorId!: string;
+
+  @Prop({ type: String, enum: SchedulePhase, required: true })
+  phase!: SchedulePhase;
+
+  @Prop({ required: true })
+  startDatetime!: Date;
+
+  @Prop({ required: true })
+  endDatetime!: Date;
+
+  @Prop({ type: Boolean, default: false })
+  superseded!: boolean;
+}
+
+export const ScheduleSchema = SchemaFactory.createForClass(Schedule);

--- a/backend/src/schedules/schedules.controller.ts
+++ b/backend/src/schedules/schedules.controller.ts
@@ -1,0 +1,40 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../auth/enums/role.enum';
+import { SchedulesService } from './schedules.service';
+import { SetScheduleDto } from './dto/set-schedule.dto';
+import { SchedulePhase } from './schedule.schema';
+
+@ApiTags('Schedules')
+@Controller('schedules')
+@UseGuards(JwtAuthGuard)
+export class SchedulesController {
+  constructor(private readonly schedulesService: SchedulesService) {}
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @Roles(Role.Coordinator)
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() dto: SetScheduleDto, @Req() req: any) {
+    return this.schedulesService.create(dto, req.user.userId as string);
+  }
+
+  @Get('active')
+  @ApiQuery({ name: 'phase', enum: SchedulePhase, required: true })
+  getActive(@Query('phase') phase: SchedulePhase) {
+    return this.schedulesService.getActive(phase);
+  }
+}

--- a/backend/src/schedules/schedules.module.ts
+++ b/backend/src/schedules/schedules.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Schedule, ScheduleSchema } from './schedule.schema';
+import { SchedulesService } from './schedules.service';
+import { SchedulesController } from './schedules.controller';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Schedule.name, schema: ScheduleSchema },
+    ]),
+  ],
+  controllers: [SchedulesController],
+  providers: [SchedulesService],
+  exports: [SchedulesService],
+})
+export class SchedulesModule {}

--- a/backend/src/schedules/schedules.service.ts
+++ b/backend/src/schedules/schedules.service.ts
@@ -1,0 +1,79 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Schedule, ScheduleDocument, SchedulePhase } from './schedule.schema';
+import { SetScheduleDto } from './dto/set-schedule.dto';
+
+@Injectable()
+export class SchedulesService {
+  constructor(
+    @InjectModel(Schedule.name)
+    private readonly scheduleModel: Model<ScheduleDocument>,
+  ) {}
+
+  async create(dto: SetScheduleDto, coordinatorId: string) {
+    const start = new Date(dto.startDatetime);
+    const end = new Date(dto.endDatetime);
+
+    if (end <= start) {
+      throw new BadRequestException(
+        'endDatetime must be strictly after startDatetime',
+      );
+    }
+
+    await this.scheduleModel
+      .updateMany({ phase: dto.phase, superseded: false }, { superseded: true })
+      .exec();
+
+    const schedule = await this.scheduleModel.create({
+      coordinatorId,
+      phase: dto.phase,
+      startDatetime: start,
+      endDatetime: end,
+    });
+
+    return this.toResponse(schedule);
+  }
+
+  async getActive(phase: SchedulePhase) {
+    const schedule = await this.scheduleModel
+      .findOne({ phase, superseded: false })
+      .sort({ createdAt: -1 })
+      .exec();
+
+    if (!schedule) {
+      throw new NotFoundException(
+        `No active schedule found for phase: ${phase}`,
+      );
+    }
+
+    const now = new Date();
+    const isOpen =
+      now >= schedule.startDatetime && now <= schedule.endDatetime;
+
+    return {
+      scheduleId: schedule.scheduleId,
+      coordinatorId: schedule.coordinatorId,
+      phase: schedule.phase,
+      startDatetime: schedule.startDatetime,
+      endDatetime: schedule.endDatetime,
+      isOpen,
+      createdAt: (schedule as any).createdAt,
+    };
+  }
+
+  private toResponse(schedule: ScheduleDocument) {
+    return {
+      scheduleId: schedule.scheduleId,
+      coordinatorId: schedule.coordinatorId,
+      phase: schedule.phase,
+      startDatetime: schedule.startDatetime,
+      endDatetime: schedule.endDatetime,
+      createdAt: (schedule as any).createdAt,
+    };
+  }
+}


### PR DESCRIPTION
1. PR Type
Feature: Adds new functionality.

2. Purpose & Description

Problem Statement:
There was no schedule window management in the system. Coordinators had no way to define time-bounded windows for advisor selection or committee assignment phases. Without this, downstream features (advisor request submission, group-to-committee assignment) could not enforce timing constraints.

Changes Made:

Added [SchedulesModule](vscode-file://vscode-app/c:/Users/leven/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with Mongoose schema (Schedule), supporting ADVISOR_SELECTION and COMMITTEE_ASSIGNMENT phases
Added POST /schedules endpoint — COORDINATOR only; validates endDatetime > startDatetime, supersedes previous active schedule for the same phase, derives coordinatorId from JWT
Added [GET /schedules/active?phase=...](vscode-file://vscode-app/c:/Users/leven/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) endpoint — any authenticated user; returns the latest non-superseded schedule with computed isOpen field
Added SetScheduleDto with [phase](vscode-file://vscode-app/c:/Users/leven/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html), startDatetime, endDatetime validation
Registered [SchedulesModule](vscode-file://vscode-app/c:/Users/leven/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [AppModule](vscode-file://vscode-app/c:/Users/leven/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Related Issue: #20

3. Testing & Verification

What Was Tested:

POST /schedules with valid COORDINATOR token → 201 with Schedule object
POST /schedules with endDatetime <= startDatetime → 400 Bad Request
POST /schedules with non-COORDINATOR role → 403 Forbidden
POST /schedules twice for same phase → previous schedule marked superseded: true
GET /schedules/active?phase=ADVISOR_SELECTION within window → isOpen: true
GET /schedules/active?phase=ADVISOR_SELECTION outside window → isOpen: false
GET /schedules/active?phase=COMMITTEE_ASSIGNMENT with no schedule → 404
Verification Steps:

4. Strict Checklist

 My PR targets the main branch.
 I have kept the changes strictly focused on the stated purpose.
 No existing functionality is broken by these changes.
5. Executive Summary

Implements the schedule window management endpoints for Issue #20. Coordinators can now define and override time windows for ADVISOR_SELECTION and COMMITTEE_ASSIGNMENT phases via POST /schedules. The GET /schedules/active endpoint exposes the current active schedule with a computed isOpen flag, which will be consumed by the advisor request submission flow (Issue #19) and committee group assignment flow (Issue #38) to enforce window constraints.