### PR TITLE
feat(backend): add committee-group removal and group disband endpoints

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -237,7 +237,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2152,7 +2151,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2200,7 +2198,6 @@
       "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2296,7 +2293,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
       "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2645,7 +2641,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2784,7 +2779,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2970,7 +2964,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3678,7 +3671,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3728,7 +3720,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3993,7 +3984,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4258,7 +4248,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4545,15 +4534,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5471,7 +5458,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5532,7 +5518,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7089,7 +7074,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8639,7 +8623,6 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.3.3.tgz",
       "integrity": "sha512-sfv5LOIPWeN5o/281kp4Rx9ZnuXb0g8CtvBTi7trYQs2PYYx8LWXegXxG3ar7VEns1o+d4h9LI/Dtc7dTTyYmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "kareem": "3.2.0",
         "mongodb": "~7.1",
@@ -9080,7 +9063,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9326,7 +9308,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9521,8 +9502,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/repeating": {
       "version": "2.0.1",
@@ -9732,7 +9712,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10596,7 +10575,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10972,7 +10950,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11155,7 +11132,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11522,7 +11498,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11592,7 +11567,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/backend/src/groups/committee-groups.controller.spec.ts
+++ b/backend/src/groups/committee-groups.controller.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommitteeGroupsController } from './committee-groups.controller';
+import { GroupsService } from './groups.service';
+
+describe('CommitteeGroupsController', () => {
+  let controller: CommitteeGroupsController;
+  let service: GroupsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommitteeGroupsController],
+      providers: [
+        {
+          provide: GroupsService,
+          useValue: {
+            removeGroupFromCommittee: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CommitteeGroupsController>(CommitteeGroupsController);
+    service = module.get<GroupsService>(GroupsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should remove group from committee using delete body groupId', async () => {
+    await controller.removeGroupFromCommittee('committee-1', { groupId: 'group-1' });
+
+    expect(service.removeGroupFromCommittee).toHaveBeenCalledWith('committee-1', 'group-1');
+  });
+});

--- a/backend/src/groups/committee-groups.controller.ts
+++ b/backend/src/groups/committee-groups.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Delete, HttpCode, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiNoContentResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../auth/enums/role.enum';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { RemoveCommitteeGroupDto } from './dto/remove-committee-group.dto';
+import { GroupsService } from './groups.service';
+
+@ApiTags('Committee Groups')
+@Controller('committees')
+export class CommitteeGroupsController {
+  constructor(private readonly groupsService: GroupsService) {}
+
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Remove group from committee' })
+  @ApiBody({ type: RemoveCommitteeGroupDto })
+  @ApiNoContentResponse({ description: 'Group assignment removed' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.Coordinator)
+  @Delete(':committeeId/groups')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeGroupFromCommittee(
+    @Param('committeeId') committeeId: string,
+    @Body() body: RemoveCommitteeGroupDto,
+  ): Promise<void> {
+    await this.groupsService.removeGroupFromCommittee(committeeId, body.groupId);
+  }
+}

--- a/backend/src/groups/dto/remove-committee-group.dto.ts
+++ b/backend/src/groups/dto/remove-committee-group.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsUUID } from 'class-validator';
 
 export class RemoveCommitteeGroupDto {
   @ApiProperty({
     example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
     description: 'Group id to remove from committee',
   })
-  @IsString()
+  @IsUUID()
   @IsNotEmpty()
   groupId!: string;
 }

--- a/backend/src/groups/dto/remove-committee-group.dto.ts
+++ b/backend/src/groups/dto/remove-committee-group.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RemoveCommitteeGroupDto {
+  @ApiProperty({
+    example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+    description: 'Group id to remove from committee',
+  })
+  @IsString()
+  @IsNotEmpty()
+  groupId!: string;
+}

--- a/backend/src/groups/group.entity.ts
+++ b/backend/src/groups/group.entity.ts
@@ -8,7 +8,7 @@ export enum GroupStatus {
   ACTIVE = 'Active',
   ASSIGNED = 'ASSIGNED',
   UNASSIGNED = 'UNASSIGNED',
-  DISBANDED = 'Disbanded',
+  DISBANDED = 'DISBANDED',
 }
 
 @Schema({ timestamps: true })

--- a/backend/src/groups/group.entity.ts
+++ b/backend/src/groups/group.entity.ts
@@ -6,6 +6,8 @@ export type GroupDocument = HydratedDocument<Group>;
 
 export enum GroupStatus {
   ACTIVE = 'Active',
+  ASSIGNED = 'ASSIGNED',
+  UNASSIGNED = 'UNASSIGNED',
   DISBANDED = 'Disbanded',
 }
 

--- a/backend/src/groups/groups.controller.spec.ts
+++ b/backend/src/groups/groups.controller.spec.ts
@@ -11,6 +11,7 @@ describe('GroupsController', () => {
   beforeEach(async () => {
     const mockService = {
       createGroup: jest.fn(),
+      disbandGroup: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -51,5 +52,12 @@ describe('GroupsController', () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(service.createGroup).toHaveBeenCalledWith(createGroupDto);
     expect(result).toEqual(expectedResult);
+  });
+
+  it('should disband a group', async () => {
+    await controller.disbandGroup('group-1');
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.disbandGroup).toHaveBeenCalledWith('group-1');
   });
 });

--- a/backend/src/groups/groups.controller.ts
+++ b/backend/src/groups/groups.controller.ts
@@ -1,7 +1,13 @@
 import { Controller, Post, Body, HttpCode, HttpStatus, Get, Param } from '@nestjs/common';
+import { Delete, UseGuards } from '@nestjs/common';
 import { GroupsService } from './groups.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiNoContentResponse } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../auth/enums/role.enum';
 
 @ApiTags('Groups')
 @Controller('groups')
@@ -19,5 +25,16 @@ export class GroupsController {
   @Get(':groupId/validate-statement-of-work')
   async validateSow(@Param('groupId') groupId: string) {
     return this.groupsService.validateStatementOfWork(groupId);
+  }
+
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Disband a group entirely' })
+  @ApiNoContentResponse({ description: 'Group disbanded successfully' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.Coordinator)
+  @Delete(':groupId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async disbandGroup(@Param('groupId') groupId: string): Promise<void> {
+    await this.groupsService.disbandGroup(groupId);
   }
 }

--- a/backend/src/groups/groups.module.ts
+++ b/backend/src/groups/groups.module.ts
@@ -4,13 +4,20 @@ import { GroupsController } from './groups.controller';
 import { GroupsService } from './groups.service';
 import { Group, GroupSchema } from './group.entity';
 import { Submission, SubmissionSchema } from '../submissions/schemas/submission.schema';
+import { CommitteeGroupsController } from './committee-groups.controller';
+import { CommitteeGroupAssignment, CommitteeGroupAssignmentSchema } from './schemas/committee-group-assignment.schema';
+import { AdvisorRequest, AdvisorRequestSchema } from './schemas/advisor-request.schema';
+import { User, UserSchema } from '../users/data/user.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Group.name, schema: GroupSchema }]),
-    MongooseModule.forFeature([{ name: Submission.name, schema: SubmissionSchema }])
+    MongooseModule.forFeature([{ name: Submission.name, schema: SubmissionSchema }]),
+    MongooseModule.forFeature([{ name: CommitteeGroupAssignment.name, schema: CommitteeGroupAssignmentSchema }]),
+    MongooseModule.forFeature([{ name: AdvisorRequest.name, schema: AdvisorRequestSchema }]),
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
   ],
-  controllers: [GroupsController],
+  controllers: [GroupsController, CommitteeGroupsController],
   providers: [GroupsService],
   exports: [GroupsService],
 })

--- a/backend/src/groups/groups.service.spec.ts
+++ b/backend/src/groups/groups.service.spec.ts
@@ -2,10 +2,18 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';
 import { GroupsService } from './groups.service';
 import { Group, GroupStatus } from './group.entity';
+import { Submission } from '../submissions/schemas/submission.schema';
+import { CommitteeGroupAssignment } from './schemas/committee-group-assignment.schema';
+import { AdvisorRequest, AdvisorRequestStatus } from './schemas/advisor-request.schema';
+import { User } from '../users/data/user.schema';
+import { NotFoundException } from '@nestjs/common';
 
 describe('GroupsService', () => {
   let service: GroupsService;
   let mockGroupModel: any;
+  let mockCommitteeGroupAssignmentModel: any;
+  let mockAdvisorRequestModel: any;
+  let mockUserModel: any;
 
   beforeEach(async () => {
     const mockGroup = {
@@ -22,14 +30,41 @@ describe('GroupsService', () => {
     };
 
     mockGroupModel = jest.fn().mockImplementation(() => mockGroup);
+    mockGroupModel.findOne = jest.fn();
+
+    mockCommitteeGroupAssignmentModel = {
+      findOneAndDelete: jest.fn(),
+    };
+    mockAdvisorRequestModel = {
+      deleteMany: jest.fn(),
+    };
+    mockUserModel = {
+      updateMany: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GroupsService,
         {
+          provide: getModelToken(Submission.name),
+          useValue: { find: jest.fn() },
+        },
+        {
           provide: getModelToken(Group.name),
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           useValue: mockGroupModel,
+        },
+        {
+          provide: getModelToken(CommitteeGroupAssignment.name),
+          useValue: mockCommitteeGroupAssignmentModel,
+        },
+        {
+          provide: getModelToken(AdvisorRequest.name),
+          useValue: mockAdvisorRequestModel,
+        },
+        {
+          provide: getModelToken(User.name),
+          useValue: mockUserModel,
         },
       ],
     }).compile();
@@ -54,5 +89,40 @@ describe('GroupsService', () => {
     expect(result.leaderUserId).toBe('123e4567-e89b-12d3-a456-426614174000');
     expect(result.status).toBe(GroupStatus.ACTIVE);
     expect(result.groupId).toBeDefined();
+  });
+
+  it('should throw NotFound when assignment is missing', async () => {
+    mockCommitteeGroupAssignmentModel.findOneAndDelete.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(null),
+    });
+
+    await expect(
+      service.removeGroupFromCommittee('committee-1', 'group-1'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('should disband group when status is UNASSIGNED', async () => {
+    const mockSave = jest.fn().mockResolvedValue(undefined);
+    mockGroupModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        groupId: 'group-1',
+        status: GroupStatus.UNASSIGNED,
+        save: mockSave,
+      }),
+    });
+    mockUserModel.updateMany.mockReturnValue({ exec: jest.fn() });
+    mockAdvisorRequestModel.deleteMany.mockReturnValue({ exec: jest.fn() });
+
+    await service.disbandGroup('group-1');
+
+    expect(mockUserModel.updateMany).toHaveBeenCalledWith(
+      { teamId: 'group-1' },
+      { $set: { teamId: null } },
+    );
+    expect(mockAdvisorRequestModel.deleteMany).toHaveBeenCalledWith({
+      groupId: 'group-1',
+      status: AdvisorRequestStatus.PENDING,
+    });
+    expect(mockSave).toHaveBeenCalled();
   });
 });

--- a/backend/src/groups/groups.service.spec.ts
+++ b/backend/src/groups/groups.service.spec.ts
@@ -6,7 +6,7 @@ import { Submission } from '../submissions/schemas/submission.schema';
 import { CommitteeGroupAssignment } from './schemas/committee-group-assignment.schema';
 import { AdvisorRequest, AdvisorRequestStatus } from './schemas/advisor-request.schema';
 import { User } from '../users/data/user.schema';
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 
 describe('GroupsService', () => {
   let service: GroupsService;
@@ -101,6 +101,19 @@ describe('GroupsService', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
+  it('should remove assignment when mapping exists', async () => {
+    mockCommitteeGroupAssignmentModel.findOneAndDelete.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({ committeeId: 'committee-1', groupId: 'group-1' }),
+    });
+
+    await service.removeGroupFromCommittee('committee-1', 'group-1');
+
+    expect(mockCommitteeGroupAssignmentModel.findOneAndDelete).toHaveBeenCalledWith({
+      committeeId: 'committee-1',
+      groupId: 'group-1',
+    });
+  });
+
   it('should disband group when status is UNASSIGNED', async () => {
     const mockSave = jest.fn().mockResolvedValue(undefined);
     mockGroupModel.findOne.mockReturnValue({
@@ -124,5 +137,27 @@ describe('GroupsService', () => {
       status: AdvisorRequestStatus.PENDING,
     });
     expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should throw NotFound when disbanding missing group', async () => {
+    mockGroupModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(null),
+    });
+
+    await expect(service.disbandGroup('group-404')).rejects.toThrow(NotFoundException);
+  });
+
+  it('should throw Conflict when status is not UNASSIGNED', async () => {
+    mockGroupModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        groupId: 'group-1',
+        status: GroupStatus.ASSIGNED,
+        save: jest.fn(),
+      }),
+    });
+
+    await expect(service.disbandGroup('group-1')).rejects.toThrow(ConflictException);
+    expect(mockUserModel.updateMany).not.toHaveBeenCalled();
+    expect(mockAdvisorRequestModel.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/groups/groups.service.ts
+++ b/backend/src/groups/groups.service.ts
@@ -1,15 +1,24 @@
-import { Injectable, NotFoundException} from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Group, GroupDocument, GroupStatus } from './group.entity';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { Submission } from '../submissions/schemas/submission.schema';
+import { CommitteeGroupAssignment, CommitteeGroupAssignmentDocument } from './schemas/committee-group-assignment.schema';
+import { AdvisorRequest, AdvisorRequestDocument, AdvisorRequestStatus } from './schemas/advisor-request.schema';
+import { User, UserDocument } from '../users/data/user.schema';
 
 @Injectable()
 export class GroupsService {
   constructor(
     @InjectModel(Group.name) private groupModel: Model<GroupDocument>,
     @InjectModel(Submission.name) private submissionModel: Model<Submission>,
+    @InjectModel(CommitteeGroupAssignment.name)
+    private committeeGroupAssignmentModel: Model<CommitteeGroupAssignmentDocument>,
+    @InjectModel(AdvisorRequest.name)
+    private advisorRequestModel: Model<AdvisorRequestDocument>,
+    @InjectModel(User.name)
+    private userModel: Model<UserDocument>,
   ) {}
 
   async createGroup(createGroupDto: CreateGroupDto): Promise<Group> {
@@ -60,5 +69,35 @@ export class GroupsService {
       overallValidationStatus: validationState,
       canClearSowStatus: validationState === 'Approved'
     };
+  }
+
+  async removeGroupFromCommittee(committeeId: string, groupId: string): Promise<void> {
+    const deletedAssignment = await this.committeeGroupAssignmentModel
+      .findOneAndDelete({ committeeId, groupId })
+      .exec();
+
+    if (!deletedAssignment) {
+      throw new NotFoundException('Committee-group assignment not found');
+    }
+  }
+
+  async disbandGroup(groupId: string): Promise<void> {
+    const group = await this.groupModel.findOne({ groupId }).exec();
+
+    if (!group) {
+      throw new NotFoundException('Group not found');
+    }
+
+    if (group.status !== GroupStatus.UNASSIGNED) {
+      throw new ConflictException('Group status must be UNASSIGNED before disbanding');
+    }
+
+    await this.userModel.updateMany({ teamId: groupId }, { $set: { teamId: null } }).exec();
+    await this.advisorRequestModel
+      .deleteMany({ groupId, status: AdvisorRequestStatus.PENDING })
+      .exec();
+
+    group.status = GroupStatus.DISBANDED;
+    await group.save();
   }
 }

--- a/backend/src/groups/groups.service.ts
+++ b/backend/src/groups/groups.service.ts
@@ -89,7 +89,9 @@ export class GroupsService {
     }
 
     if (group.status !== GroupStatus.UNASSIGNED) {
-      throw new ConflictException('Group status must be UNASSIGNED before disbanding');
+      throw new ConflictException(
+        'Group must be UNASSIGNED before disbanding. Release advisor assignment first.',
+      );
     }
 
     await this.userModel.updateMany({ teamId: groupId }, { $set: { teamId: null } }).exec();

--- a/backend/src/groups/schemas/advisor-request.schema.ts
+++ b/backend/src/groups/schemas/advisor-request.schema.ts
@@ -1,0 +1,21 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type AdvisorRequestDocument = HydratedDocument<AdvisorRequest>;
+
+export enum AdvisorRequestStatus {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+}
+
+@Schema({ timestamps: true })
+export class AdvisorRequest {
+  @Prop({ required: true })
+  groupId!: string;
+
+  @Prop({ required: true, enum: AdvisorRequestStatus })
+  status!: AdvisorRequestStatus;
+}
+
+export const AdvisorRequestSchema = SchemaFactory.createForClass(AdvisorRequest);

--- a/backend/src/groups/schemas/committee-group-assignment.schema.ts
+++ b/backend/src/groups/schemas/committee-group-assignment.schema.ts
@@ -1,0 +1,18 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type CommitteeGroupAssignmentDocument =
+  HydratedDocument<CommitteeGroupAssignment>;
+
+@Schema({ timestamps: true })
+export class CommitteeGroupAssignment {
+  @Prop({ required: true })
+  committeeId!: string;
+
+  @Prop({ required: true })
+  groupId!: string;
+}
+
+export const CommitteeGroupAssignmentSchema = SchemaFactory.createForClass(
+  CommitteeGroupAssignment,
+);


### PR DESCRIPTION
## 1. PR Type
Feature: Adds new functionality.

## 2. Purpose & Description

### Problem Statement
The backend did not provide complete coordinator-driven lifecycle management for committee-group relations and group disbanding. Specifically, there was no dedicated flow to (1) remove a group from a committee assignment via the API contract in issue #37 and (2) disband a group with required business rules (status precondition, student cleanup, pending advisor-request cleanup, and final status update).

### Changes Made
- Added coordinator-only endpoint for removing a group from a committee:
  - `DELETE /committees/:committeeId/groups` (accepts `groupId` in request body)
- Added coordinator-only endpoint for disbanding a group:
  - `DELETE /groups/:groupId`
- Implemented business rules for disband flow:
  - Returns `404` if group does not exist
  - Enforces `UNASSIGNED` precondition before disbanding (`409` on violation)
  - Clears student-group links (`teamId/groupId -> null` according to current schema usage)
  - Deletes pending advisor requests for the group
  - Marks group status as `DISBANDED`
- Added/updated supporting DTOs, schemas, module wiring, and unit tests for the new behaviors.

## 3. Testing & Verification

### What Was Tested
- Committee-group removal returns `204` on success and `404` when mapping does not exist
- Group disband returns `204` on success for eligible groups
- Group disband rejects non-`UNASSIGNED` status with conflict response
- Group disband updates related records:
  - Student group references cleared
  - Pending advisor requests deleted
  - Group status updated to `DISBANDED`
- Role protection is enforced for coordinator-only access paths

### Verification Steps
```bash
cd backend
npm install
npm test -- src/groups/groups.controller.spec.ts src/groups/groups.service.spec.ts