### PR TITLE
Add withdraw advisor request feature

### DIFF
--- a/backend/src/advisors/advisor-requests.controller.spec.ts
+++ b/backend/src/advisors/advisor-requests.controller.spec.ts
@@ -3,6 +3,7 @@ import { Role } from '../auth/enums/role.enum';
 import { AdvisorRequestsController } from './advisor-requests.controller';
 import { AdvisorsService } from './advisors.service';
 import { AdvisorDecision } from './dto/decision-request.dto';
+import { WithdrawRequestStatus } from './dto/update-request-status.dto';
 
 type SubmitRequestArg = Parameters<
   AdvisorRequestsController['submitRequest']
@@ -16,6 +17,12 @@ type DecideRequestArg = Parameters<
 type DecideRequestBody = Parameters<
   AdvisorRequestsController['decideRequest']
 >[2];
+type WithdrawRequestArg = Parameters<
+  AdvisorRequestsController['withdrawRequest']
+>[0];
+type WithdrawRequestBody = Parameters<
+  AdvisorRequestsController['withdrawRequest']
+>[2];
 
 describe('AdvisorRequestsController', () => {
   let controller: AdvisorRequestsController;
@@ -23,6 +30,7 @@ describe('AdvisorRequestsController', () => {
   const mockAdvisorsService = {
     submitRequest: jest.fn(),
     decideRequest: jest.fn(),
+    withdrawRequest: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -100,6 +108,38 @@ describe('AdvisorRequestsController', () => {
       requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
       advisorId: 'advisor-1',
       decision: AdvisorDecision.APPROVE,
+    });
+    expect(result).toEqual(expected);
+  });
+
+  it('should delegate withdraw request to service for team leaders', async () => {
+    const expected = {
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-1',
+      requestedAdvisorId: 'advisor-1',
+      status: 'WITHDRAWN',
+    };
+
+    mockAdvisorsService.withdrawRequest.mockResolvedValue(expected);
+
+    const request = {
+      user: { role: Role.TeamLeader, userId: 'team-leader-1' },
+    } as WithdrawRequestArg;
+
+    const body: WithdrawRequestBody = {
+      status: WithdrawRequestStatus.WITHDRAWN,
+    };
+
+    const result = await controller.withdrawRequest(
+      request,
+      'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      body,
+    );
+
+    expect(mockAdvisorsService.withdrawRequest).toHaveBeenCalledWith({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      teamLeaderId: 'team-leader-1',
     });
     expect(result).toEqual(expected);
   });

--- a/backend/src/advisors/advisor-requests.controller.ts
+++ b/backend/src/advisors/advisor-requests.controller.ts
@@ -20,6 +20,10 @@ import {
   DecisionRequestDto,
 } from './dto/decision-request.dto';
 import { SubmitRequestDto } from './dto/submit-request.dto';
+import {
+  UpdateRequestStatusDto,
+  WithdrawRequestStatus,
+} from './dto/update-request-status.dto';
 import { AdvisorRequestStatus } from './schemas/advisor-request.schema';
 
 interface RequestWithUser extends Request {
@@ -139,6 +143,53 @@ export class AdvisorRequestsController {
         (body.decision === AdvisorDecision.APPROVE
           ? AdvisorRequestStatus.APPROVED
           : AdvisorRequestStatus.REJECTED),
+      createdAt: requestRecord.createdAt,
+      updatedAt: requestRecord.updatedAt,
+    };
+  }
+
+  @Patch(':requestId')
+  @Roles(Role.TeamLeader)
+  async withdrawRequest(
+    @Req() req: RequestWithUser,
+    @Param('requestId', new ParseUUIDPipe({ version: '4' })) requestId: string,
+    @Body() body: UpdateRequestStatusDto,
+  ) {
+    const teamLeaderId = req.user?.userId;
+    const correlationId = this.getCorrelationId(req);
+
+    const result = await this.advisorsService.withdrawRequest({
+      requestId,
+      teamLeaderId: teamLeaderId ?? '',
+    });
+
+    const requestRecord = result as unknown as {
+      requestId: string;
+      groupId: string;
+      submittedBy: string;
+      requestedAdvisorId: string;
+      status?: string;
+      createdAt?: string;
+      updatedAt?: string;
+    };
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'advisor_request_withdrawn',
+        requestId: requestRecord.requestId,
+        groupId: requestRecord.groupId,
+        teamLeaderId,
+        requestedStatus: body.status,
+        correlationId,
+      }),
+    );
+
+    return {
+      requestId: requestRecord.requestId,
+      groupId: requestRecord.groupId,
+      submittedBy: requestRecord.submittedBy,
+      requestedAdvisorId: requestRecord.requestedAdvisorId,
+      status: requestRecord.status ?? WithdrawRequestStatus.WITHDRAWN,
       createdAt: requestRecord.createdAt,
       updatedAt: requestRecord.updatedAt,
     };

--- a/backend/src/advisors/advisors.service.spec.ts
+++ b/backend/src/advisors/advisors.service.spec.ts
@@ -94,6 +94,7 @@ describe('AdvisorsService', () => {
     notifyAdvisorRequestSubmitted: jest.fn(),
     notifyAdvisorRequestApproved: jest.fn(),
     notifyAdvisorRequestRejected: jest.fn(),
+    notifyAdvisorRequestWithdrawn: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -709,6 +710,182 @@ describe('AdvisorsService', () => {
     expect(
       mockNotificationsService.notifyAdvisorRequestApproved,
     ).not.toHaveBeenCalled();
+  });
+
+  it('should withdraw pending request and notify requested advisor', async () => {
+    mockAdvisorRequestModel.findOne.mockReturnValue(
+      mockAdvisorRequestFindOneQuery,
+    );
+    mockAdvisorRequestFindOneQuery.exec
+      .mockResolvedValueOnce({
+        requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        groupId: 'group-1',
+        submittedBy: 'team-leader-1',
+        requestedAdvisorId: 'advisor-1',
+        status: AdvisorRequestStatus.PENDING,
+      })
+      .mockResolvedValueOnce({
+        requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        groupId: 'group-1',
+        submittedBy: 'team-leader-1',
+        requestedAdvisorId: 'advisor-1',
+        status: AdvisorRequestStatus.WITHDRAWN,
+      });
+
+    mockAdvisorRequestModel.findOneAndUpdate.mockReturnValue(
+      mockAdvisorRequestFindOneAndUpdateQuery,
+    );
+    mockAdvisorRequestFindOneAndUpdateQuery.exec.mockResolvedValue({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-1',
+      requestedAdvisorId: 'advisor-1',
+      status: AdvisorRequestStatus.WITHDRAWN,
+    });
+
+    const result = await service.withdrawRequest({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      teamLeaderId: 'team-leader-1',
+    });
+
+    expect(result.status).toBe(AdvisorRequestStatus.WITHDRAWN);
+    expect(mockAdvisorRequestModel.findOneAndUpdate).toHaveBeenCalledWith(
+      {
+        requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        submittedBy: 'team-leader-1',
+        status: AdvisorRequestStatus.PENDING,
+      },
+      { $set: { status: AdvisorRequestStatus.WITHDRAWN } },
+      { returnDocument: 'after' },
+    );
+    expect(
+      mockNotificationsService.notifyAdvisorRequestWithdrawn,
+    ).toHaveBeenCalledWith({
+      recipientUserId: 'advisor-1',
+      groupId: 'group-1',
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    });
+  });
+
+  it('should return 404 when withdrawing a non-existent request', async () => {
+    mockAdvisorRequestModel.findOne.mockReturnValue(
+      mockAdvisorRequestFindOneQuery,
+    );
+    mockAdvisorRequestFindOneQuery.exec.mockResolvedValue(null);
+
+    await expect(
+      service.withdrawRequest({
+        requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        teamLeaderId: 'team-leader-1',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('should return 403 when team leader does not own request', async () => {
+    mockAdvisorRequestModel.findOne.mockReturnValue(
+      mockAdvisorRequestFindOneQuery,
+    );
+    mockAdvisorRequestFindOneQuery.exec.mockResolvedValue({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-2',
+      requestedAdvisorId: 'advisor-1',
+      status: AdvisorRequestStatus.PENDING,
+    });
+
+    await expect(
+      service.withdrawRequest({
+        requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        teamLeaderId: 'team-leader-1',
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('should return 409 when withdrawing a non-pending request', async () => {
+    mockAdvisorRequestModel.findOne.mockReturnValue(
+      mockAdvisorRequestFindOneQuery,
+    );
+    mockAdvisorRequestFindOneQuery.exec.mockResolvedValue({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-1',
+      requestedAdvisorId: 'advisor-1',
+      status: AdvisorRequestStatus.APPROVED,
+    });
+
+    await expect(
+      service.withdrawRequest({
+        requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        teamLeaderId: 'team-leader-1',
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('should return 409 when request is concurrently transitioned before withdrawal', async () => {
+    mockAdvisorRequestModel.findOne.mockReturnValue(
+      mockAdvisorRequestFindOneQuery,
+    );
+    mockAdvisorRequestFindOneQuery.exec.mockResolvedValue({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-1',
+      requestedAdvisorId: 'advisor-1',
+      status: AdvisorRequestStatus.PENDING,
+    });
+
+    mockAdvisorRequestModel.findOneAndUpdate.mockReturnValue(
+      mockAdvisorRequestFindOneAndUpdateQuery,
+    );
+    mockAdvisorRequestFindOneAndUpdateQuery.exec.mockResolvedValue(null);
+
+    await expect(
+      service.withdrawRequest({
+        requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        teamLeaderId: 'team-leader-1',
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('should map unknown failures in withdraw request to internal server error', async () => {
+    mockAdvisorRequestModel.findOne.mockReturnValue(
+      mockAdvisorRequestFindOneQuery,
+    );
+    mockAdvisorRequestFindOneQuery.exec.mockResolvedValue({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-1',
+      requestedAdvisorId: 'advisor-1',
+      status: AdvisorRequestStatus.PENDING,
+    });
+
+    mockAdvisorRequestModel.findOneAndUpdate.mockReturnValue(
+      mockAdvisorRequestFindOneAndUpdateQuery,
+    );
+    mockAdvisorRequestFindOneAndUpdateQuery.exec.mockResolvedValue({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-1',
+      requestedAdvisorId: 'advisor-1',
+      status: AdvisorRequestStatus.WITHDRAWN,
+    });
+
+    mockAdvisorRequestFindOneQuery.exec.mockResolvedValueOnce({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-1',
+      requestedAdvisorId: 'advisor-1',
+      status: AdvisorRequestStatus.PENDING,
+    });
+    mockAdvisorRequestFindOneQuery.exec.mockRejectedValueOnce(
+      new Error('db down'),
+    );
+
+    await expect(
+      service.withdrawRequest({
+        requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        teamLeaderId: 'team-leader-1',
+      }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
   });
 
   it('should return advisor response fields in API contract shape', async () => {

--- a/backend/src/advisors/advisors.service.ts
+++ b/backend/src/advisors/advisors.service.ts
@@ -92,6 +92,11 @@ export interface DecideRequestInput {
   decision: AdvisorDecision;
 }
 
+export interface WithdrawRequestInput {
+  requestId: string;
+  teamLeaderId: string;
+}
+
 @Injectable()
 export class AdvisorsService {
   constructor(
@@ -409,6 +414,87 @@ export class AdvisorsService {
 
       throw new InternalServerErrorException(
         'Failed to decide advisor request.',
+      );
+    }
+  }
+
+  async withdrawRequest(input: WithdrawRequestInput): Promise<AdvisorRequest> {
+    if (!input.teamLeaderId) {
+      throw new ForbiddenException('Invalid authenticated user.');
+    }
+
+    try {
+      const existingRequest = await this.advisorRequestModel
+        .findOne({ requestId: input.requestId })
+        .lean<AdvisorRequest>()
+        .exec();
+
+      if (!existingRequest) {
+        throw new NotFoundException('Advisor request was not found.');
+      }
+
+      if (existingRequest.submittedBy !== input.teamLeaderId) {
+        throw new ForbiddenException(
+          'You are not allowed to withdraw this advisor request.',
+        );
+      }
+
+      if (existingRequest.status !== AdvisorRequestStatus.PENDING) {
+        throw new ConflictException(
+          'Advisor request is not in a pending state.',
+        );
+      }
+
+      const withdrawnRequest = await this.advisorRequestModel
+        .findOneAndUpdate(
+          {
+            requestId: input.requestId,
+            submittedBy: input.teamLeaderId,
+            status: AdvisorRequestStatus.PENDING,
+          },
+          { $set: { status: AdvisorRequestStatus.WITHDRAWN } },
+          { returnDocument: 'after' },
+        )
+        .lean<AdvisorRequest>()
+        .exec();
+
+      if (!withdrawnRequest) {
+        throw new ConflictException('Advisor request is no longer pending.');
+      }
+
+      const updatedRequest = await this.advisorRequestModel
+        .findOne({
+          requestId: input.requestId,
+          submittedBy: input.teamLeaderId,
+        })
+        .lean<AdvisorRequest>()
+        .exec();
+
+      if (!updatedRequest) {
+        throw new InternalServerErrorException(
+          'Failed to withdraw advisor request.',
+        );
+      }
+
+      await this.notificationsService.notifyAdvisorRequestWithdrawn({
+        recipientUserId: updatedRequest.requestedAdvisorId,
+        groupId: updatedRequest.groupId,
+        requestId: updatedRequest.requestId,
+      });
+
+      return updatedRequest;
+    } catch (error: unknown) {
+      if (
+        error instanceof NotFoundException ||
+        error instanceof ConflictException ||
+        error instanceof ForbiddenException ||
+        error instanceof HttpException
+      ) {
+        throw error;
+      }
+
+      throw new InternalServerErrorException(
+        'Failed to withdraw advisor request.',
       );
     }
   }

--- a/backend/src/advisors/dto/update-request-status.dto.ts
+++ b/backend/src/advisors/dto/update-request-status.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { AdvisorRequestStatus } from '../schemas/advisor-request.schema';
+
+export enum WithdrawRequestStatus {
+  WITHDRAWN = AdvisorRequestStatus.WITHDRAWN,
+}
+
+export class UpdateRequestStatusDto {
+  @IsNotEmpty()
+  @IsEnum(WithdrawRequestStatus)
+  status!: WithdrawRequestStatus;
+}

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -70,4 +70,18 @@ export class NotificationsService {
     const savedNotification = await notification.save();
     return { notificationId: savedNotification._id.toString() };
   }
+
+  async notifyAdvisorRequestWithdrawn(
+    input: AdvisorRequestDecisionNotificationInput,
+  ) {
+    const notification = new this.notificationModel({
+      recipientUserId: input.recipientUserId,
+      groupId: input.groupId,
+      type: 'AdvisorRequestWithdrawn',
+      requestId: input.requestId,
+    });
+
+    const savedNotification = await notification.save();
+    return { notificationId: savedNotification._id.toString() };
+  }
 }

--- a/backend/test/advisor-requests.e2e-spec.ts
+++ b/backend/test/advisor-requests.e2e-spec.ts
@@ -14,6 +14,7 @@ import * as jwt from 'jsonwebtoken';
 import { AdvisorRequestsController } from '../src/advisors/advisor-requests.controller';
 import { AdvisorsService } from '../src/advisors/advisors.service';
 import { AdvisorDecision } from '../src/advisors/dto/decision-request.dto';
+import { WithdrawRequestStatus } from '../src/advisors/dto/update-request-status.dto';
 import { Role } from '../src/auth/enums/role.enum';
 import { JwtStrategy } from '../src/auth/jwt.strategy';
 import { UsersService } from '../src/users/users.service';
@@ -36,6 +37,13 @@ describe('Advisor Requests (e2e)', () => {
       submittedBy: 'team-leader-id',
       requestedAdvisorId: 'advisor-id',
       status: 'APPROVED',
+    }),
+    withdrawRequest: jest.fn().mockResolvedValue({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-id',
+      requestedAdvisorId: 'advisor-id',
+      status: 'WITHDRAWN',
     }),
   };
 
@@ -262,6 +270,96 @@ describe('Advisor Requests (e2e)', () => {
       submittedBy: 'team-leader-id',
       requestedAdvisorId: 'advisor-id',
       status: 'APPROVED',
+    });
+  });
+
+  it('PATCH /requests/:requestId should return 401 when missing bearer token', () => {
+    return request(app.getHttpServer())
+      .patch('/requests/f47ac10b-58cc-4372-a567-0e02b2c3d479')
+      .send({ status: WithdrawRequestStatus.WITHDRAWN })
+      .expect(401);
+  });
+
+  it('PATCH /requests/:requestId should return 403 for non-team-leader role', () => {
+    const token = createToken('advisor-id');
+
+    return request(app.getHttpServer())
+      .patch('/requests/f47ac10b-58cc-4372-a567-0e02b2c3d479')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: WithdrawRequestStatus.WITHDRAWN })
+      .expect(403);
+  });
+
+  it('PATCH /requests/:requestId should return 400 for invalid request id', () => {
+    const token = createToken('team-leader-id');
+
+    return request(app.getHttpServer())
+      .patch('/requests/not-a-uuid')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: WithdrawRequestStatus.WITHDRAWN })
+      .expect(400);
+  });
+
+  it('PATCH /requests/:requestId should return 404 when request is not found', () => {
+    const token = createToken('team-leader-id');
+    mockAdvisorsService.withdrawRequest.mockRejectedValueOnce(
+      new NotFoundException('Advisor request was not found.'),
+    );
+
+    return request(app.getHttpServer())
+      .patch('/requests/f47ac10b-58cc-4372-a567-0e02b2c3d479')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: WithdrawRequestStatus.WITHDRAWN })
+      .expect(404);
+  });
+
+  it('PATCH /requests/:requestId should return 409 when request is not pending', () => {
+    const token = createToken('team-leader-id');
+    mockAdvisorsService.withdrawRequest.mockRejectedValueOnce(
+      new ConflictException('Advisor request is not in a pending state.'),
+    );
+
+    return request(app.getHttpServer())
+      .patch('/requests/f47ac10b-58cc-4372-a567-0e02b2c3d479')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: WithdrawRequestStatus.WITHDRAWN })
+      .expect(409);
+  });
+
+  it('PATCH /requests/:requestId should return 403 when caller is not the submitter', () => {
+    const token = createToken('team-leader-id');
+    mockAdvisorsService.withdrawRequest.mockRejectedValueOnce(
+      new ForbiddenException(
+        'You are not allowed to withdraw this advisor request.',
+      ),
+    );
+
+    return request(app.getHttpServer())
+      .patch('/requests/f47ac10b-58cc-4372-a567-0e02b2c3d479')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: WithdrawRequestStatus.WITHDRAWN })
+      .expect(403);
+  });
+
+  it('PATCH /requests/:requestId should return 200 for valid team leader withdraw', async () => {
+    const token = createToken('team-leader-id');
+
+    const response = await request(app.getHttpServer())
+      .patch('/requests/f47ac10b-58cc-4372-a567-0e02b2c3d479')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: WithdrawRequestStatus.WITHDRAWN })
+      .expect(200);
+
+    expect(mockAdvisorsService.withdrawRequest).toHaveBeenCalledWith({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      teamLeaderId: 'team-leader-id',
+    });
+    expect(response.body).toEqual({
+      requestId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      groupId: 'group-1',
+      submittedBy: 'team-leader-id',
+      requestedAdvisorId: 'advisor-id',
+      status: 'WITHDRAWN',
     });
   });
 });

--- a/postman/collections/issue23-withdraw-advisor-request.postman_collection.json
+++ b/postman/collections/issue23-withdraw-advisor-request.postman_collection.json
@@ -1,0 +1,355 @@
+{
+  "info": {
+    "name": "Issue 23 - Withdraw Advisor Request",
+    "description": "Issue 23 flow for Team Leader withdrawal of a pending advisor request via PATCH /requests/:requestId.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Setup",
+      "item": [
+        {
+          "name": "1) Login Team Leader",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{teamLeaderEmail}}\",\n  \"password\": \"{{teamLeaderPassword}}\"\n}"
+            },
+            "url": "{{baseUrl}}/auth/login"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200 OK', function () {",
+                  "  pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.accessToken).to.be.a('string');",
+                  "pm.environment.set('teamLeaderToken', body.accessToken);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "2) Login Coordinator",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{coordinatorEmail}}\",\n  \"password\": \"{{coordinatorPassword}}\"\n}"
+            },
+            "url": "{{baseUrl}}/auth/login"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200 OK', function () {",
+                  "  pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.accessToken).to.be.a('string');",
+                  "pm.environment.set('coordinatorToken', body.accessToken);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "3) Ensure Active Advisor Selection Schedule",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{coordinatorToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"phase\": \"ADVISOR_SELECTION\",\n  \"startDatetime\": \"2025-01-01T00:00:00.000Z\",\n  \"endDatetime\": \"2030-12-31T23:59:59.000Z\"\n}"
+            },
+            "url": "{{baseUrl}}/schedules"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201 Created or 200 OK', function () {",
+                  "  pm.expect([200, 201]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "4) List Advisors and Capture advisorId",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teamLeaderToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/advisors"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200 OK', function () {",
+                  "  pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data).to.be.an('array').that.is.not.empty;",
+                  "pm.environment.set('advisorId', body.data[0].advisorId);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "5) Create Pending Request",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teamLeaderToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"requestedAdvisorId\": \"{{advisorId}}\"\n}"
+            },
+            "url": "{{baseUrl}}/requests"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201 Created or 200 OK', function () {",
+                  "  pm.expect([200, 201]).to.include(pm.response.code);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.requestId).to.be.a('string');",
+                  "pm.environment.set('requestIdPending', body.requestId);"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Withdraw Scenarios",
+      "item": [
+        {
+          "name": "✓ PATCH Withdraw - Happy Path",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teamLeaderToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"WITHDRAWN\"\n}"
+            },
+            "url": "{{baseUrl}}/requests/{{requestIdPending}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200 OK', function () {",
+                  "  pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.requestId).to.be.a('string');",
+                  "pm.expect(body.status).to.equal('WITHDRAWN');"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "✗ PATCH Withdraw - Missing JWT (401)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"WITHDRAWN\"\n}"
+            },
+            "url": "{{baseUrl}}/requests/{{requestIdPending}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 401 Unauthorized', function () {",
+                  "  pm.expect(pm.response.code).to.equal(401);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "✗ PATCH Withdraw - Invalid Request ID (400)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teamLeaderToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"WITHDRAWN\"\n}"
+            },
+            "url": "{{baseUrl}}/requests/not-a-uuid"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 400 Bad Request', function () {",
+                  "  pm.expect(pm.response.code).to.equal(400);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "✗ PATCH Withdraw - Not Found (404)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teamLeaderToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"WITHDRAWN\"\n}"
+            },
+            "url": "{{baseUrl}}/requests/00000000-0000-4000-8000-000000000000"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 404 Not Found', function () {",
+                  "  pm.expect(pm.response.code).to.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "✗ PATCH Withdraw - Not Pending (409)",
+          "description": "Run after the happy-path request has already been withdrawn once.",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teamLeaderToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"WITHDRAWN\"\n}"
+            },
+            "url": "{{baseUrl}}/requests/{{requestIdPending}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 409 Conflict', function () {",
+                  "  pm.expect(pm.response.code).to.equal(409);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/postman/environments/issue23-local.postman_environment.json
+++ b/postman/environments/issue23-local.postman_environment.json
@@ -1,0 +1,54 @@
+{
+  "id": "issue23-local",
+  "name": "Issue 23 - Local Environment",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3001/api/v1",
+      "enabled": true
+    },
+    {
+      "key": "teamLeaderEmail",
+      "value": "teamleader@example.com",
+      "enabled": true
+    },
+    {
+      "key": "teamLeaderPassword",
+      "value": "SecurePass123",
+      "enabled": true
+    },
+    {
+      "key": "coordinatorEmail",
+      "value": "coordinator@example.com",
+      "enabled": true
+    },
+    {
+      "key": "coordinatorPassword",
+      "value": "SecurePass123",
+      "enabled": true
+    },
+    {
+      "key": "advisorId",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "teamLeaderToken",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "coordinatorToken",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "requestIdPending",
+      "value": "",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-04-16T00:00:00.000Z",
+  "_postman_exported_using": "Postman/v11.0.0"
+}


### PR DESCRIPTION
## Summary
This PR adds the Issue 23 withdraw flow for advisor requests. Team Leaders can now withdraw their own pending advisor request through `PATCH /requests/:requestId`, the request status transitions to `WITHDRAWN`, and the requested advisor receives a withdrawal notification.

Closes #23

---

## Type of Change
<!-- Check all that apply -->
- [x] Feature (new endpoint or business logic)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Configuration / infrastructure
- [ ] Background job / scheduled task
- [ ] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change
<!-- List the files, modules, or layers touched. Be specific. -->

**Backend:**
- Controller(s): `backend/src/advisors/advisor-requests.controller.ts`
- Use case(s) / service(s): `backend/src/advisors/advisors.service.ts`, `backend/src/notifications/notifications.service.ts`
- Repository / DB layer: advisor request update flow uses existing Mongoose models and atomic conditional update
- Schema / migration: `backend/src/advisors/dto/update-request-status.dto.ts`, existing advisor request status enum
- OpenAPI spec file(s): existing process4 contract already matched by implementation

**Frontend:** (if applicable)
- Component(s): N/A
- API client / DTO: N/A

**Infrastructure / Config:** (if applicable)
- Postman collection and environment for Issue 23 flows

---

## API Contract Alignment
<!-- Only fill in if this PR touches an endpoint -->

| Field | Value |
|---|---|
| Endpoint | `PATCH /requests/:requestId` |
| OperationId | `updateRequestStatus` |
| OpenAPI file | process4.yaml |
| Spec updated in this PR | No |

- [x] Response shape matches OpenAPI schema exactly
- [x] All documented status codes are reachable via implementation
- [x] No fields added to response that are not in the spec
- [x] groupId / actorId extracted from JWT — NOT from request body (if applicable)

---

## Clean Architecture Checklist
<!-- Verify the layer boundaries defined in the issue acceptance criteria -->

**Infrastructure / API layer:**
- [x] Auth guard behavior matches status code matrix in issue
- [x] Controller returns contract-compliant response shape
- [x] Input validation rules enforced (required fields, UUID format, enum values)

**Application / Use Case layer:**
- [x] Use case orchestrates all validations before any DB write
- [x] Sensitive fields never exposed in response DTOs
- [x] Error mapping is deterministic — same input always produces same error code

**Domain / Repository layer:**
- [x] Repository queries enforce correct domain filters (role scoping, ownership)
- [x] Concurrency / uniqueness constraints protected at DB level, not only application level
- [x] All DB failures caught and mapped to generic 500 — no raw DB errors reach the client

---

## Test Evidence
<!-- Fill in what was tested. Link to test files where possible. -->

**Unit tests:**
- [x] Happy path covered
- [x] All business-rule failure cases covered (see Section 11 of issue)
- [x] Repository failure mapping tested

**Controller tests:**
- [x] 401 unauthorized (missing/invalid JWT)
- [x] 403 forbidden (wrong role or ownership mismatch)
- [x] Success response shape and status code
- [x] Validation error response (400)

**Integration / E2E tests:**
- [x] Happy flow end-to-end
- [x] Conflict / locked / not-found flow end-to-end
- [x] Contract parity with OpenAPI verified

**Test file locations:**
- Unit: [backend/src/advisors/advisors.service.spec.ts](backend/src/advisors/advisors.service.spec.ts)
- Controller: [backend/src/advisors/advisor-requests.controller.spec.ts](backend/src/advisors/advisor-requests.controller.spec.ts)
- E2E: [backend/test/advisor-requests.e2e-spec.ts](backend/test/advisor-requests.e2e-spec.ts)

**Test run output:**
- Advisor unit tests: pass
- Advisor controller tests: pass
- Advisor e2e tests: pass
- Full backend unit suite: pass
- Full backend e2e suite: pass
- Postman flow: pass after seeding test users

---

## Status Code Matrix Verification
<!-- Confirm every documented status code is reachable -->

| Code | Scenario | Tested |
|---|---|---|
| 2xx | Happy path | [x] |
| 400 | Validation failure | [x] |
| 401 | Missing/invalid JWT | [x] |
| 403 | Role or ownership mismatch | [x] |
| 404 | Resource not found | [x] |
| 409 | Conflict | [x] |
| 4xx | Other (specify) | [x] 423 for already assigned group on submit flow |
| 500 | DB/internal failure | [x] |

---

## Observability Checklist
<!-- From Section 12 of issue -->
- [x] Key business event is logged with correlationId / requestId
- [x] No secrets, tokens, hashes, or sensitive personal data in logs
- [x] 500 responses include actionable internal context in server logs
- [ ] Audit log entry written (if this is a POST, PATCH, or DELETE operation — requires Issue 47 to be merged first)

---

## Migration / Breaking Change Assessment
- [x] No database migration required
- [ ] Migration included and tested with rollback plan
- [x] No breaking change to API contract
- [ ] Breaking change — existing consumers notified: N/A
- [x] Backward compatibility note: Existing decision endpoint unchanged; withdraw is added as a separate PATCH route

---

## Out of Scope Confirmation
<!-- From Section 14 of issue — confirm these were NOT implemented -->
The following are explicitly out of scope for this PR and were not implemented:
- Database schema redesign
- Transaction-based workflow changes
- Group lifecycle changes
- Coordinator override behavior
- Any audit logging work from Issue 47
- Frontend UI changes

---

## Dependencies
<!-- List any PRs, issues, or external changes this PR depends on -->
- Blocked by: none
- Must be merged before: Issue 24 and later advisor-flow work that depends on withdraw semantics
- Requires Issue 47 (Audit logging) to be merged first: No

---

## Reviewer Notes
- I initially saw 401s in Postman because test users had not been seeded yet. After running the seed step, the login and full Postman flow worked.
- The withdraw endpoint is intentionally separate from the advisor decision endpoint and only accepts TeamLeader-owned pending requests.
- The existing advisor decision flow from Issue 22 remains unchanged.

---

## Definition of Done Sign-off
- [ ] Implementation merged with passing tests
- [x] OpenAPI spec updated and aligned with implementation
- [x] QA scenarios executed and evidenced above
- [x] PR description includes test evidence and status-matrix coverage
- [x] No TODO comments left in production code
- [x] No console.log or debug statements left in code