### PR TITLE
Implement Issue 38: assign group to committee

### DIFF
--- a/backend/src/committees/committees.controller.spec.ts
+++ b/backend/src/committees/committees.controller.spec.ts
@@ -1,9 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import {
+  ConflictException,
   ExecutionContext,
   ForbiddenException,
+  HttpException,
   InternalServerErrorException,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Reflector } from '@nestjs/core';
@@ -42,6 +45,7 @@ describe('CommitteesController', () => {
       getCommitteeByGroupId: jest.fn(),
       listCommitteeGroups: jest.fn(),
       listCommitteeAdvisors: jest.fn(),
+      assignGroupToCommittee: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -621,6 +625,116 @@ describe('CommitteesController', () => {
       } as unknown as ExecutionContext;
 
       expect(() => rolesGuard.canActivate(ctx)).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('POST /committees/:committeeId/groups', () => {
+    const committeeId = mockCommittee.id;
+    const payload = { groupId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' };
+
+    it('valid COORDINATOR, valid body -> 201 with CommitteeGroupResponse', async () => {
+      jest.spyOn(service, 'assignGroupToCommittee').mockResolvedValue({
+        groupId: payload.groupId,
+        assignedAt: now,
+        assignedByUserId: coordinatorUser.userId,
+      });
+
+      const req = { user: coordinatorUser, headers: {} } as any;
+      const result = await controller.assignGroupToCommittee(committeeId, payload, req);
+
+      expect(result).toEqual({
+        groupId: payload.groupId,
+        assignedAt: now,
+        assignedByUserId: coordinatorUser.userId,
+      });
+    });
+
+    it('delegates to service with committeeId, body, coordinatorId, correlationId', async () => {
+      jest.spyOn(service, 'assignGroupToCommittee').mockResolvedValue({
+        groupId: payload.groupId,
+        assignedAt: now,
+        assignedByUserId: coordinatorUser.userId,
+      });
+
+      const req = {
+        user: coordinatorUser,
+        headers: { 'x-correlation-id': 'corr-38' },
+      } as any;
+      await controller.assignGroupToCommittee(committeeId, payload, req);
+
+      expect(service.assignGroupToCommittee).toHaveBeenCalledWith(
+        committeeId,
+        payload,
+        coordinatorUser.userId,
+        'corr-38',
+      );
+    });
+
+    it('group has no advisor -> propagates 422', async () => {
+      jest
+        .spyOn(service, 'assignGroupToCommittee')
+        .mockRejectedValue(
+          new UnprocessableEntityException(
+            'Group does not have a confirmed advisor assignment.',
+          ),
+        );
+
+      const req = { user: coordinatorUser, headers: {} } as any;
+      await expect(
+        controller.assignGroupToCommittee(committeeId, payload, req),
+      ).rejects.toBeInstanceOf(UnprocessableEntityException);
+    });
+
+    it('schedule window closed -> propagates 423', async () => {
+      jest
+        .spyOn(service, 'assignGroupToCommittee')
+        .mockRejectedValue(
+          new HttpException('Committee assignment schedule window is closed.', 423),
+        );
+
+      const req = { user: coordinatorUser, headers: {} } as any;
+      await expect(
+        controller.assignGroupToCommittee(committeeId, payload, req),
+      ).rejects.toMatchObject({ status: 423 });
+    });
+
+    it('group already assigned -> propagates 409', async () => {
+      jest
+        .spyOn(service, 'assignGroupToCommittee')
+        .mockRejectedValue(new ConflictException('Group is already assigned to a committee.'));
+
+      const req = { user: coordinatorUser, headers: {} } as any;
+      await expect(
+        controller.assignGroupToCommittee(committeeId, payload, req),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('committee not found -> propagates 404', async () => {
+      jest
+        .spyOn(service, 'assignGroupToCommittee')
+        .mockRejectedValue(
+          new NotFoundException(`Committee with ID '${committeeId}' not found.`),
+        );
+
+      const req = { user: coordinatorUser, headers: {} } as any;
+      await expect(
+        controller.assignGroupToCommittee(committeeId, payload, req),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('repository failure -> propagates 500', async () => {
+      jest
+        .spyOn(service, 'assignGroupToCommittee')
+        .mockRejectedValue(
+          new InternalServerErrorException(
+            'Failed to assign group to committee due to an unexpected error.',
+          ),
+        );
+
+      const req = { user: coordinatorUser, headers: {} } as any;
+      await expect(
+        controller.assignGroupToCommittee(committeeId, payload, req),
+      ).rejects.toBeInstanceOf(InternalServerErrorException);
     });
   });
 });

--- a/backend/src/committees/committees.controller.ts
+++ b/backend/src/committees/committees.controller.ts
@@ -15,12 +15,14 @@ import { AuthGuard } from '@nestjs/passport';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
+  ApiConflictResponse,
   ApiForbiddenResponse,
   ApiInternalServerErrorResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
+  ApiUnprocessableEntityResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { Request as ExpressRequest } from 'express';
@@ -35,6 +37,8 @@ import { ListCommitteeGroupsQueryDto } from './dto/list-committee-groups-query.d
 import { CommitteeGroupPageDto } from './dto/committee-group-page.dto';
 import { ListCommitteeAdvisorsQueryDto } from './dto/list-committee-advisors-query.dto';
 import { CommitteeAdvisorPageDto } from './dto/committee-advisor-page.dto';
+import { AssignCommitteeGroupDto } from './dto/assign-committee-group.dto';
+import { CommitteeGroupResponseDto } from './dto/committee-group-response.dto';
 
 interface RequestWithUser extends ExpressRequest {
   user: { userId?: string; sub?: string; _id?: string; role: string };
@@ -177,6 +181,48 @@ export class CommitteesController {
     return this.committeesService.listCommitteeGroups(
       committeeId,
       query,
+      correlationId,
+    );
+  }
+
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    operationId: 'assignGroupToCommittee',
+    summary: 'Assign a group to a committee (COORDINATOR only)',
+  })
+  @ApiCreatedResponse({
+    description: 'Group assigned successfully',
+    type: CommitteeGroupResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiForbiddenResponse({
+    description: 'Valid token but insufficient permissions',
+  })
+  @ApiNotFoundResponse({ description: 'Committee or group not found' })
+  @ApiConflictResponse({
+    description: 'Group is already assigned to a committee',
+  })
+  @ApiUnprocessableEntityResponse({
+    description: 'Group does not have a confirmed advisor assignment',
+  })
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(Role.Coordinator)
+  @Post(':committeeId/groups')
+  @HttpCode(HttpStatus.CREATED)
+  async assignGroupToCommittee(
+    @Param('committeeId', new ParseUUIDPipe()) committeeId: string,
+    @Body() dto: AssignCommitteeGroupDto,
+    @Request() req: RequestWithUser,
+  ): Promise<CommitteeGroupResponseDto> {
+    const coordinatorId =
+      req.user.userId ?? req.user.sub ?? req.user._id ?? 'unknown';
+    const correlationId =
+      (req.headers['x-correlation-id'] as string) ?? undefined;
+
+    return this.committeesService.assignGroupToCommittee(
+      committeeId,
+      dto,
+      coordinatorId,
       correlationId,
     );
   }

--- a/backend/src/committees/committees.module.ts
+++ b/backend/src/committees/committees.module.ts
@@ -4,12 +4,14 @@ import { Committee, CommitteeSchema } from './schemas/committee.schema';
 import { CommitteesService } from './committees.service';
 import { CommitteesController } from './committees.controller';
 import { Group, GroupSchema } from '../groups/group.entity';
+import { Schedule, ScheduleSchema } from '../advisors/schemas/schedule.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: Committee.name, schema: CommitteeSchema },
       { name: Group.name, schema: GroupSchema },
+      { name: Schedule.name, schema: ScheduleSchema },
     ]),
   ],
   controllers: [CommitteesController],

--- a/backend/src/committees/committees.service.spec.ts
+++ b/backend/src/committees/committees.service.spec.ts
@@ -1,14 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';
 import {
+  ConflictException,
   InternalServerErrorException,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { CommitteesService } from './committees.service';
 import { Committee } from './schemas/committee.schema';
 import { Group } from '../groups/group.entity';
 import { ListCommitteeGroupsQueryDto } from './dto/list-committee-groups-query.dto';
 import { ListCommitteeAdvisorsQueryDto } from './dto/list-committee-advisors-query.dto';
+import { Schedule } from '../advisors/schemas/schedule.schema';
 
 describe('CommitteesService', () => {
   let service: CommitteesService;
@@ -28,9 +31,14 @@ describe('CommitteesService', () => {
   const mockCommitteeModel = {
     create: jest.fn(),
     findOne: jest.fn(),
+    updateOne: jest.fn(),
   };
 
   const mockGroupModel = {
+    findOne: jest.fn(),
+  };
+
+  const mockScheduleModel = {
     findOne: jest.fn(),
   };
 
@@ -47,6 +55,10 @@ describe('CommitteesService', () => {
         {
           provide: getModelToken(Group.name),
           useValue: mockGroupModel,
+        },
+        {
+          provide: getModelToken(Schedule.name),
+          useValue: mockScheduleModel,
         },
       ],
     }).compile();
@@ -474,6 +486,184 @@ describe('CommitteesService', () => {
         id: committeeId,
       });
       expect(result.total).toBe(2);
+    });
+  });
+
+  describe('assignGroupToCommittee', () => {
+    const committeeId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const groupId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    const advisorId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+    function mockOpenSchedule() {
+      const start = new Date(Date.now() - 10 * 60 * 1000);
+      const end = new Date(Date.now() + 10 * 60 * 1000);
+      mockScheduleModel.findOne.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          lean: jest.fn().mockReturnValue({
+            exec: jest
+              .fn()
+              .mockResolvedValue({ startDatetime: start, endDatetime: end }),
+          }),
+        }),
+      });
+    }
+
+    it('happy path: advisor auto-linked when missing', async () => {
+      mockOpenSchedule();
+      mockCommitteeModel.findOne
+        .mockReturnValueOnce({
+          exec: jest
+            .fn()
+            .mockResolvedValue({ ...mockCommittee, id: committeeId, advisors: [], groups: [] }),
+        })
+        .mockReturnValueOnce({
+          lean: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(null) }),
+        });
+      mockGroupModel.findOne.mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue({ groupId, assignedAdvisorId: advisorId }),
+        }),
+      });
+      mockCommitteeModel.updateOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+      });
+
+      const result = await service.assignGroupToCommittee(
+        committeeId,
+        { groupId },
+        'coord-1',
+      );
+
+      expect(result.groupId).toBe(groupId);
+      expect(result.assignedByUserId).toBe('coord-1');
+      expect(result.assignedAt).toBeInstanceOf(Date);
+      expect(mockCommitteeModel.updateOne).toHaveBeenCalled();
+    });
+
+    it('happy path: advisor already linked -> no duplicate advisor link', async () => {
+      mockOpenSchedule();
+      mockCommitteeModel.findOne
+        .mockReturnValueOnce({
+          exec: jest.fn().mockResolvedValue({
+            ...mockCommittee,
+            id: committeeId,
+            advisors: [{ advisorId, assignedAt: now, assignedByUserId: 'coord-0' }],
+            groups: [],
+          }),
+        })
+        .mockReturnValueOnce({
+          lean: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(null) }),
+        });
+      mockGroupModel.findOne.mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue({ groupId, assignedAdvisorId: advisorId }),
+        }),
+      });
+      mockCommitteeModel.updateOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+      });
+
+      await service.assignGroupToCommittee(committeeId, { groupId }, 'coord-1');
+
+      const updatePayload = mockCommitteeModel.updateOne.mock.calls[0][1].$set;
+      expect(updatePayload.advisors).toHaveLength(1);
+      expect(updatePayload.advisors[0].advisorId).toBe(advisorId);
+    });
+
+    it('failure: group already assigned -> 409', async () => {
+      mockOpenSchedule();
+      mockCommitteeModel.findOne
+        .mockReturnValueOnce({
+          exec: jest.fn().mockResolvedValue({ ...mockCommittee, id: committeeId }),
+        })
+        .mockReturnValueOnce({
+          lean: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue({ id: 'existing-committee' }),
+          }),
+        });
+      mockGroupModel.findOne.mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue({ groupId, assignedAdvisorId: advisorId }),
+        }),
+      });
+
+      await expect(
+        service.assignGroupToCommittee(committeeId, { groupId }, 'coord-1'),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('failure: group has no advisor -> 422', async () => {
+      mockOpenSchedule();
+      mockCommitteeModel.findOne.mockReturnValueOnce({
+        exec: jest.fn().mockResolvedValue({ ...mockCommittee, id: committeeId }),
+      });
+      mockGroupModel.findOne.mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue({ groupId, assignedAdvisorId: null }),
+        }),
+      });
+
+      await expect(
+        service.assignGroupToCommittee(committeeId, { groupId }, 'coord-1'),
+      ).rejects.toBeInstanceOf(UnprocessableEntityException);
+    });
+
+    it('failure: schedule window closed -> 423', async () => {
+      mockScheduleModel.findOne.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          lean: jest.fn().mockReturnValue({
+            exec: jest
+              .fn()
+              .mockResolvedValue({
+                startDatetime: new Date(Date.now() - 20 * 60 * 1000),
+                endDatetime: new Date(Date.now() - 10 * 60 * 1000),
+              }),
+          }),
+        }),
+      });
+
+      await expect(
+        service.assignGroupToCommittee(committeeId, { groupId }, 'coord-1'),
+      ).rejects.toMatchObject({ status: 423 });
+    });
+
+    it('failure: committee not found -> 404', async () => {
+      mockOpenSchedule();
+      mockCommitteeModel.findOne.mockReturnValueOnce({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.assignGroupToCommittee(committeeId, { groupId }, 'coord-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('failure: group not found -> 404', async () => {
+      mockOpenSchedule();
+      mockCommitteeModel.findOne.mockReturnValueOnce({
+        exec: jest.fn().mockResolvedValue({ ...mockCommittee, id: committeeId }),
+      });
+      mockGroupModel.findOne.mockReturnValue({
+        lean: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(null) }),
+      });
+
+      await expect(
+        service.assignGroupToCommittee(committeeId, { groupId }, 'coord-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('failure: repository throws -> 500', async () => {
+      mockScheduleModel.findOne.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          lean: jest.fn().mockReturnValue({
+            exec: jest.fn().mockRejectedValue(new Error('db error')),
+          }),
+        }),
+      });
+
+      await expect(
+        service.assignGroupToCommittee(committeeId, { groupId }, 'coord-1'),
+      ).rejects.toBeInstanceOf(InternalServerErrorException);
     });
   });
 });

--- a/backend/src/committees/committees.service.ts
+++ b/backend/src/committees/committees.service.ts
@@ -1,8 +1,11 @@
 import {
+  ConflictException,
+  HttpException,
   Injectable,
   InternalServerErrorException,
   Logger,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
@@ -19,6 +22,13 @@ import {
   CommitteeAdvisorPageDto,
 } from './dto/committee-advisor-page.dto';
 import { Group, GroupDocument } from '../groups/group.entity';
+import {
+  Schedule,
+  ScheduleDocument,
+  SchedulePhase,
+} from '../advisors/schemas/schedule.schema';
+import { AssignCommitteeGroupDto } from './dto/assign-committee-group.dto';
+import { CommitteeGroupResponseDto } from './dto/committee-group-response.dto';
 
 @Injectable()
 export class CommitteesService {
@@ -29,6 +39,8 @@ export class CommitteesService {
     private readonly committeeModel: Model<CommitteeDocument>,
     @InjectModel(Group.name)
     private readonly groupModel: Model<GroupDocument>,
+    @InjectModel(Schedule.name)
+    private readonly scheduleModel: Model<ScheduleDocument>,
   ) {}
 
   async createCommittee(
@@ -244,6 +256,145 @@ export class CommitteesService {
       });
       throw new InternalServerErrorException(
         'Failed to retrieve committee due to an unexpected error.',
+      );
+    }
+  }
+
+  async assignGroupToCommittee(
+    committeeId: string,
+    dto: AssignCommitteeGroupDto,
+    coordinatorId: string,
+    correlationId?: string,
+  ): Promise<CommitteeGroupResponseDto> {
+    const startedAt = Date.now();
+    try {
+      const schedule = await this.scheduleModel
+        .findOne({ phase: SchedulePhase.COMMITTEE_ASSIGNMENT, isActive: true })
+        .sort({ createdAt: -1 })
+        .lean<{ startDatetime: Date; endDatetime: Date } | null>()
+        .exec();
+
+      const scheduleLatencyMs = Date.now() - startedAt;
+      const now = Date.now();
+      const scheduleOpen =
+        schedule !== null &&
+        now >= new Date(schedule.startDatetime).getTime() &&
+        now <= new Date(schedule.endDatetime).getTime();
+
+      this.logger.log({
+        event: 'committee_assignment_schedule_check',
+        phase: SchedulePhase.COMMITTEE_ASSIGNMENT,
+        isOpen: scheduleOpen,
+        latencyMs: scheduleLatencyMs,
+        committeeId,
+        groupId: dto.groupId,
+        coordinatorId,
+        correlationId,
+      });
+
+      if (!scheduleOpen) {
+        throw new HttpException(
+          'Committee assignment schedule window is closed.',
+          423,
+        );
+      }
+
+      const committee = await this.committeeModel.findOne({ id: committeeId }).exec();
+      if (!committee) {
+        throw new NotFoundException(`Committee with ID '${committeeId}' not found.`);
+      }
+
+      const group = await this.groupModel.findOne({ groupId: dto.groupId }).lean<Group>().exec();
+      if (!group) {
+        throw new NotFoundException(`Group with ID '${dto.groupId}' not found.`);
+      }
+
+      if (!group.assignedAdvisorId) {
+        throw new UnprocessableEntityException(
+          'Group does not have a confirmed advisor assignment.',
+        );
+      }
+
+      const existingCommitteeForGroup = await this.committeeModel
+        .findOne({ 'groups.groupId': dto.groupId })
+        .lean<{ id: string } | null>()
+        .exec();
+      if (existingCommitteeForGroup) {
+        throw new ConflictException('Group is already assigned to a committee.');
+      }
+
+      const assignedAt = dto.assignedAt ? new Date(dto.assignedAt) : new Date();
+      const advisorAlreadyLinked = ((committee.advisors as any[]) ?? []).some(
+        (advisor) =>
+          advisor.advisorId === group.assignedAdvisorId ||
+          advisor.userId === group.assignedAdvisorId ||
+          advisor.advisorUserId === group.assignedAdvisorId,
+      );
+
+      const groupsToPersist = [
+        ...((committee.groups as any[]) ?? []),
+        {
+          groupId: dto.groupId,
+          assignedAt,
+          assignedByUserId: coordinatorId,
+        },
+      ];
+      const advisorsToPersist = advisorAlreadyLinked
+        ? ((committee.advisors as any[]) ?? [])
+        : [
+            ...((committee.advisors as any[]) ?? []),
+            {
+              advisorId: group.assignedAdvisorId,
+              assignedAt,
+              assignedByUserId: coordinatorId,
+              assignmentSource: 'PRIMARY_ADVISOR',
+            },
+          ];
+
+      const updateResult = await this.committeeModel
+        .updateOne(
+          { id: committeeId, 'groups.groupId': { $ne: dto.groupId } },
+          { $set: { groups: groupsToPersist, advisors: advisorsToPersist } },
+        )
+        .exec();
+
+      if (updateResult.modifiedCount === 0) {
+        throw new ConflictException('Group is already assigned to a committee.');
+      }
+
+      this.logger.log({
+        event: 'group_assigned_to_committee',
+        committeeId,
+        groupId: dto.groupId,
+        advisorAutoLinked: !advisorAlreadyLinked,
+        coordinatorId,
+        correlationId,
+      });
+
+      return {
+        groupId: dto.groupId,
+        assignedAt,
+        assignedByUserId: coordinatorId,
+      };
+    } catch (error) {
+      if (
+        error instanceof NotFoundException ||
+        error instanceof ConflictException ||
+        error instanceof UnprocessableEntityException ||
+        (error instanceof HttpException && error.getStatus() === 423)
+      ) {
+        throw error;
+      }
+      this.logger.error({
+        event: 'group_assign_to_committee_failed',
+        committeeId,
+        groupId: dto.groupId,
+        coordinatorId,
+        correlationId,
+        error: (error as Error).message,
+      });
+      throw new InternalServerErrorException(
+        'Failed to assign group to committee due to an unexpected error.',
       );
     }
   }

--- a/backend/src/committees/dto/assign-committee-group.dto.ts
+++ b/backend/src/committees/dto/assign-committee-group.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+
+export class AssignCommitteeGroupDto {
+  @ApiProperty({
+    description: 'Identifier of the group to assign',
+    format: 'uuid',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  groupId!: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional assignment timestamp, defaults to current server time',
+    format: 'date-time',
+  })
+  @IsOptional()
+  @IsDateString()
+  assignedAt?: string;
+}

--- a/backend/src/committees/dto/committee-group-response.dto.ts
+++ b/backend/src/committees/dto/committee-group-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CommitteeGroupResponseDto {
+  @ApiProperty({ description: 'Group identifier', format: 'uuid' })
+  groupId!: string;
+
+  @ApiProperty({
+    description: 'Assignment timestamp',
+    format: 'date-time',
+  })
+  assignedAt!: Date;
+
+  @ApiProperty({
+    description: 'Coordinator ID who made this assignment',
+    format: 'uuid',
+  })
+  assignedByUserId!: string;
+}

--- a/backend/test/committee-groups.e2e-spec.ts
+++ b/backend/test/committee-groups.e2e-spec.ts
@@ -18,12 +18,14 @@ describe('Committee Groups (e2e)', () => {
 
   const now = new Date('2025-06-02T12:00:00.000Z');
   const committeeId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const validGroupId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
 
   const mockCommitteesService = {
     createCommittee: jest.fn(),
     getCommitteeById: jest.fn(),
     getCommitteeByGroupId: jest.fn(),
     listCommitteeGroups: jest.fn(),
+    assignGroupToCommittee: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -125,6 +127,68 @@ describe('Committee Groups (e2e)', () => {
     expect(mockCommitteesService.listCommitteeGroups).toHaveBeenCalledWith(
       committeeId,
       expect.objectContaining({ page: 1, limit: 20 }),
+      undefined,
+    );
+  });
+
+  it('POST No JWT -> 401', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/v1/committees/${committeeId}/groups`)
+      .send({ groupId: validGroupId })
+      .expect(401);
+  });
+
+  it('POST ADVISOR role -> 403', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/v1/committees/${committeeId}/groups`)
+      .set('Authorization', 'Bearer test-token')
+      .set('x-test-role', Role.Professor)
+      .send({ groupId: validGroupId })
+      .expect(403);
+  });
+
+  it('POST TEAM_LEADER role -> 403', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/v1/committees/${committeeId}/groups`)
+      .set('Authorization', 'Bearer test-token')
+      .set('x-test-role', Role.TeamLeader)
+      .send({ groupId: validGroupId })
+      .expect(403);
+  });
+
+  it('POST missing groupId -> 400', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/v1/committees/${committeeId}/groups`)
+      .set('Authorization', 'Bearer test-token')
+      .set('x-test-role', Role.Coordinator)
+      .send({})
+      .expect(400);
+  });
+
+  it('POST valid COORDINATOR, valid body -> 201 with CommitteeGroupResponse', async () => {
+    mockCommitteesService.assignGroupToCommittee.mockResolvedValue({
+      groupId: validGroupId,
+      assignedAt: now,
+      assignedByUserId: 'test-user',
+    });
+
+    const response = await request(app.getHttpServer())
+      .post(`/api/v1/committees/${committeeId}/groups`)
+      .set('Authorization', 'Bearer test-token')
+      .set('x-test-role', Role.Coordinator)
+      .send({ groupId: validGroupId })
+      .expect(201);
+
+    expect(response.body).toEqual({
+      groupId: validGroupId,
+      assignedAt: now.toISOString(),
+      assignedByUserId: 'test-user',
+    });
+
+    expect(mockCommitteesService.assignGroupToCommittee).toHaveBeenCalledWith(
+      committeeId,
+      { groupId: validGroupId },
+      'test-user',
       undefined,
     );
   });


### PR DESCRIPTION
Summary
Implemented POST /committees/{committeeId}/groups for Issue 38 to allow COORDINATOR users to assign a group to a committee.
Added business-rule enforcement for committee assignment flow: schedule window validation (423), advisor prerequisite validation (422), committee/group existence checks (404), duplicate assignment prevention (409), and server-time defaulting for assignedAt.
Added automatic primary-advisor linking to committee during group assignment when missing, with silent skip when already linked, while preserving assignedByUserId as the coordinator from JWT.
Added endpoint DTO/response contract support and expanded unit + controller + e2e test coverage for success and error matrix scenarios.
Test Evidence
npm test -- committees.service.spec.ts ✅
npm test -- committees.controller.spec.ts ✅
npm run test:e2e -- committee-groups.e2e-spec.ts ✅
Status Matrix Coverage
201 group assigned successfully (with/without advisor auto-link)
400 invalid payload (missing groupId)
401 missing/invalid JWT
403 non-coordinator role blocked
404 committee or group not found
409 group already assigned to a committee
422 group has no confirmed advisor
423 committee assignment window closed
500 unexpected repository/internal failure