### PR TITLE
feat(frontend): add coordinator management suite for schedules and co…

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { AuthProvider } from './context/AuthContext';
 import { ProtectedRoute } from './components/ProtectedRoute';
 
 import GroupLifecyclePage from './pages/GroupLifecyclePage';
+import CoordinatorManagementPage from './pages/CoordinatorManagementPage';
 import RegisterPage from './pages/RegisterPage';
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
@@ -33,6 +34,7 @@ function App() {
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/groups" element={<GroupLifecyclePage />} />
             <Route path="/all-groups" element={<GroupLifecyclePage />} />
+            <Route path="/coordinator-management" element={<CoordinatorManagementPage />} />
             <Route path="/documents" element={<div>Documents Section - Coming Soon</div>} />
           </Route>
 

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -47,6 +47,12 @@ export const Sidebar = () => {
             >
               🏢 <span style={styles.linkText}>All Groups</span>
             </NavLink>
+            <NavLink
+              to="/coordinator-management"
+              style={({ isActive }) => ({ ...styles.link, ...(isActive ? styles.activeLink : {}) })}
+            >
+              🗂️ <span style={styles.linkText}>Coordinator Suite</span>
+            </NavLink>
           </>
         )}
       </nav>

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -19,6 +19,16 @@ export const apiConfig = {
     invites: '/invites/deliver',
     advisorValidation: '/admin/advisor-validation',
     sanitizationExecute: '/admin/sanitization/execute',
+    schedules: '/schedules',
+    schedulesActive: '/schedules/active',
+    committees: '/committees',
+    committeeById: (committeeId) => `/committees/${committeeId}`,
+    committeeJuryMembers: (committeeId) => `/committees/${committeeId}/jury-members`,
+    committeeJuryMemberByUser: (committeeId, userId) => `/committees/${committeeId}/jury-members/${userId}`,
+    committeeAdvisors: (committeeId) => `/committees/${committeeId}/advisors`,
+    committeeAdvisorByUser: (committeeId, advisorUserId) => `/committees/${committeeId}/advisors/${advisorUserId}`,
+    committeeGroups: (committeeId) => `/committees/${committeeId}/groups`,
+    committeeGroupById: (committeeId, groupId) => `/committees/${committeeId}/groups/${groupId}`,
   },
 };
 

--- a/frontend/src/pages/CoordinatorManagementPage.jsx
+++ b/frontend/src/pages/CoordinatorManagementPage.jsx
@@ -1,0 +1,607 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import styles from './CoordinatorManagementPage.module.css'
+import { createSchedule, getActiveSchedule } from '../utils/scheduleService'
+import {
+  addAdvisor,
+  addJuryMember,
+  assignCommitteeGroup,
+  createCommittee,
+  deleteCommittee,
+  getCommittee,
+  listAdvisors,
+  listCommitteeGroups,
+  listCommittees,
+  listJuryMembers,
+  removeAdvisor,
+  removeCommitteeGroup,
+  removeJuryMember,
+  updateCommittee,
+} from '../utils/committeeService'
+
+const emptyStatus = () => ({ message: '', error: '' })
+const TAB_KEYS = ['jury', 'advisors', 'groups']
+
+const toList = (payload) => {
+  if (Array.isArray(payload)) return payload
+  if (Array.isArray(payload?.items)) return payload.items
+  if (Array.isArray(payload?.data)) return payload.data
+  return []
+}
+
+const toPagination = (payload) => ({
+  total: payload?.total ?? payload?.meta?.total ?? null,
+  page: payload?.page ?? payload?.meta?.page ?? null,
+  limit: payload?.limit ?? payload?.meta?.limit ?? null,
+})
+
+const fromDateInput = (value) => new Date(value).toISOString()
+
+function StatusMessage({ status }) {
+  if (!status.message && !status.error) return null
+  const typeClass = status.error ? styles.error : styles.success
+  return (
+    <div className={`${styles.statusBlock} ${typeClass}`} role="status" aria-live="polite">
+      {status.error || status.message}
+    </div>
+  )
+}
+
+function SectionCard({ title, subtitle, children }) {
+  return (
+    <section className={styles.card}>
+      <div className={styles.cardHeader}>
+        <h2>{title}</h2>
+        {subtitle ? <p>{subtitle}</p> : null}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function CoordinatorManagementPage() {
+  const [scheduleForm, setScheduleForm] = useState({
+    phase: '',
+    startAt: '',
+    endAt: '',
+  })
+  const [scheduleStatus, setScheduleStatus] = useState(emptyStatus())
+  const [scheduleLoading, setScheduleLoading] = useState(false)
+  const [activeSchedule, setActiveSchedule] = useState(null)
+
+  const [filters, setFilters] = useState({ name: '', page: 1, limit: 10 })
+  const [committeeStatus, setCommitteeStatus] = useState(emptyStatus())
+  const [committeeLoading, setCommitteeLoading] = useState(false)
+  const [committees, setCommittees] = useState([])
+  const [pagination, setPagination] = useState({ total: null, page: 1, limit: 10 })
+
+  const [committeeForm, setCommitteeForm] = useState({ name: '' })
+  const [editingCommitteeId, setEditingCommitteeId] = useState(null)
+  const [selectedCommitteeId, setSelectedCommitteeId] = useState('')
+
+  const [detailStatus, setDetailStatus] = useState(emptyStatus())
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [selectedCommittee, setSelectedCommittee] = useState(null)
+
+  const [activeTab, setActiveTab] = useState('jury')
+  const [tabLoading, setTabLoading] = useState(false)
+  const [tabStatus, setTabStatus] = useState(emptyStatus())
+  const [juryMembers, setJuryMembers] = useState([])
+  const [advisors, setAdvisors] = useState([])
+  const [assignedGroups, setAssignedGroups] = useState([])
+  const [juryInput, setJuryInput] = useState('')
+  const [advisorInput, setAdvisorInput] = useState('')
+  const [groupInput, setGroupInput] = useState('')
+
+  const loadActiveSchedule = useCallback(async () => {
+    setScheduleLoading(true)
+    setScheduleStatus(emptyStatus())
+    try {
+      const data = await getActiveSchedule()
+      setActiveSchedule(data)
+      setScheduleStatus({ message: 'Active schedule loaded successfully.', error: '' })
+    } catch (error) {
+      setScheduleStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+      setActiveSchedule(null)
+    } finally {
+      setScheduleLoading(false)
+    }
+  }, [])
+
+  const loadCommittees = useCallback(async () => {
+    setCommitteeLoading(true)
+    setCommitteeStatus(emptyStatus())
+    try {
+      const payload = await listCommittees(filters)
+      setCommittees(toList(payload))
+      setPagination(toPagination(payload))
+    } catch (error) {
+      setCommitteeStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+      setCommittees([])
+    } finally {
+      setCommitteeLoading(false)
+    }
+  }, [filters])
+
+  const loadCommitteeDetails = useCallback(async (committeeId) => {
+    if (!committeeId) return
+    setDetailLoading(true)
+    setDetailStatus(emptyStatus())
+    try {
+      const data = await getCommittee(committeeId)
+      setSelectedCommittee(data)
+    } catch (error) {
+      setDetailStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+      setSelectedCommittee(null)
+    } finally {
+      setDetailLoading(false)
+    }
+  }, [])
+
+  const loadTabData = useCallback(async (committeeId, tabKey) => {
+    if (!committeeId || !TAB_KEYS.includes(tabKey)) return
+    setTabLoading(true)
+    setTabStatus(emptyStatus())
+    try {
+      if (tabKey === 'jury') {
+        setJuryMembers(toList(await listJuryMembers(committeeId)))
+      }
+      if (tabKey === 'advisors') {
+        setAdvisors(toList(await listAdvisors(committeeId)))
+      }
+      if (tabKey === 'groups') {
+        setAssignedGroups(toList(await listCommitteeGroups(committeeId)))
+      }
+    } catch (error) {
+      setTabStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+      if (tabKey === 'jury') setJuryMembers([])
+      if (tabKey === 'advisors') setAdvisors([])
+      if (tabKey === 'groups') setAssignedGroups([])
+    } finally {
+      setTabLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadActiveSchedule()
+  }, [loadActiveSchedule])
+
+  useEffect(() => {
+    loadCommittees()
+  }, [loadCommittees])
+
+  useEffect(() => {
+    if (!selectedCommitteeId) return
+    loadCommitteeDetails(selectedCommitteeId)
+    loadTabData(selectedCommitteeId, activeTab)
+  }, [selectedCommitteeId, activeTab, loadCommitteeDetails, loadTabData])
+
+  const onCreateSchedule = async (event) => {
+    event.preventDefault()
+    setScheduleStatus(emptyStatus())
+
+    if (!scheduleForm.phase.trim()) {
+      setScheduleStatus({ message: '', error: 'Phase is required.' })
+      return
+    }
+    if (!scheduleForm.startAt || !scheduleForm.endAt) {
+      setScheduleStatus({ message: '', error: 'Start and end date are required.' })
+      return
+    }
+    if (new Date(scheduleForm.startAt) >= new Date(scheduleForm.endAt)) {
+      setScheduleStatus({ message: '', error: 'End date must be after start date.' })
+      return
+    }
+
+    setScheduleLoading(true)
+    try {
+      await createSchedule({
+        phase: scheduleForm.phase.trim(),
+        startAt: fromDateInput(scheduleForm.startAt),
+        endAt: fromDateInput(scheduleForm.endAt),
+      })
+      setScheduleStatus({ message: 'Schedule created successfully.', error: '' })
+      await loadActiveSchedule()
+    } catch (error) {
+      setScheduleStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+    } finally {
+      setScheduleLoading(false)
+    }
+  }
+
+  const onSubmitCommittee = async (event) => {
+    event.preventDefault()
+    if (!committeeForm.name.trim()) {
+      setCommitteeStatus({ message: '', error: 'Committee name is required.' })
+      return
+    }
+
+    setCommitteeStatus(emptyStatus())
+    setCommitteeLoading(true)
+    try {
+      if (editingCommitteeId) {
+        await updateCommittee(editingCommitteeId, { name: committeeForm.name.trim() })
+        setCommitteeStatus({ message: 'Committee updated successfully.', error: '' })
+      } else {
+        await createCommittee({ name: committeeForm.name.trim() })
+        setCommitteeStatus({ message: 'Committee created successfully.', error: '' })
+      }
+      setCommitteeForm({ name: '' })
+      setEditingCommitteeId(null)
+      await loadCommittees()
+    } catch (error) {
+      setCommitteeStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+    } finally {
+      setCommitteeLoading(false)
+    }
+  }
+
+  const onDeleteCommittee = async (committeeId) => {
+    if (!committeeId) return
+    const approved = window.confirm('Delete this committee?')
+    if (!approved) return
+
+    setCommitteeStatus(emptyStatus())
+    setCommitteeLoading(true)
+    try {
+      await deleteCommittee(committeeId)
+      setCommitteeStatus({ message: 'Committee deleted successfully.', error: '' })
+      if (selectedCommitteeId === committeeId) {
+        setSelectedCommitteeId('')
+        setSelectedCommittee(null)
+      }
+      await loadCommittees()
+    } catch (error) {
+      setCommitteeStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+    } finally {
+      setCommitteeLoading(false)
+    }
+  }
+
+  const onAddRelation = async (event) => {
+    event.preventDefault()
+    if (!selectedCommitteeId) return
+
+    setTabStatus(emptyStatus())
+    setTabLoading(true)
+    try {
+      if (activeTab === 'jury') {
+        if (!juryInput.trim()) {
+          setTabStatus({ message: '', error: '(422) Jury user id is required.' })
+          return
+        }
+        await addJuryMember(selectedCommitteeId, juryInput.trim())
+        setJuryInput('')
+      }
+      if (activeTab === 'advisors') {
+        if (!advisorInput.trim()) {
+          setTabStatus({ message: '', error: '(422) Advisor user id is required.' })
+          return
+        }
+        await addAdvisor(selectedCommitteeId, advisorInput.trim())
+        setAdvisorInput('')
+      }
+      if (activeTab === 'groups') {
+        if (!groupInput.trim()) {
+          setTabStatus({ message: '', error: '(422) Group id is required.' })
+          return
+        }
+        await assignCommitteeGroup(selectedCommitteeId, groupInput.trim())
+        setGroupInput('')
+      }
+
+      setTabStatus({ message: 'Assignment completed successfully.', error: '' })
+      await loadTabData(selectedCommitteeId, activeTab)
+    } catch (error) {
+      setTabStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+    } finally {
+      setTabLoading(false)
+    }
+  }
+
+  const onRemoveRelation = async (id) => {
+    if (!selectedCommitteeId || !id) return
+
+    setTabStatus(emptyStatus())
+    setTabLoading(true)
+    try {
+      if (activeTab === 'jury') await removeJuryMember(selectedCommitteeId, id)
+      if (activeTab === 'advisors') await removeAdvisor(selectedCommitteeId, id)
+      if (activeTab === 'groups') await removeCommitteeGroup(selectedCommitteeId, id)
+      setTabStatus({ message: 'Relation removed successfully.', error: '' })
+      await loadTabData(selectedCommitteeId, activeTab)
+    } catch (error) {
+      setTabStatus({ message: '', error: `(${error.status ?? 'N/A'}) ${error.message}` })
+    } finally {
+      setTabLoading(false)
+    }
+  }
+
+  const activeCollection = useMemo(() => {
+    if (activeTab === 'jury') return juryMembers
+    if (activeTab === 'advisors') return advisors
+    return assignedGroups
+  }, [activeTab, juryMembers, advisors, assignedGroups])
+
+  const getRelationId = useCallback((item) => {
+    if (typeof item === 'string') return item
+    return item?.userId || item?.advisorUserId || item?.groupId || item?.id || item?.committeeId || 'unknown'
+  }, [])
+
+  const committeeMeta = useMemo(() => {
+    if (pagination.total === null) return null
+    const shownPage = pagination.page || filters.page
+    return `Page ${shownPage} / Limit ${pagination.limit || filters.limit} / Total ${pagination.total}`
+  }, [pagination, filters.page, filters.limit])
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <p className={styles.badge}>Coordinator Management Suite</p>
+        <h1>Schedules, Committees, Members and Group Assignments</h1>
+      </header>
+
+      <div className={styles.grid}>
+        <SectionCard title="Schedule Management" subtitle="Create schedule and inspect active window.">
+          <form className={styles.form} onSubmit={onCreateSchedule}>
+            <label htmlFor="phaseInput">
+              Phase
+              <input
+                id="phaseInput"
+                value={scheduleForm.phase}
+                onChange={(event) => setScheduleForm((prev) => ({ ...prev, phase: event.target.value }))}
+                placeholder="e.g. COMMITTEE_ASSIGNMENT"
+                required
+              />
+            </label>
+            <label htmlFor="startAtInput">
+              Start Date
+              <input
+                id="startAtInput"
+                type="datetime-local"
+                value={scheduleForm.startAt}
+                onChange={(event) => setScheduleForm((prev) => ({ ...prev, startAt: event.target.value }))}
+                required
+              />
+            </label>
+            <label htmlFor="endAtInput">
+              End Date
+              <input
+                id="endAtInput"
+                type="datetime-local"
+                value={scheduleForm.endAt}
+                onChange={(event) => setScheduleForm((prev) => ({ ...prev, endAt: event.target.value }))}
+                required
+              />
+            </label>
+            <div className={styles.inlineActions}>
+              <button type="submit" disabled={scheduleLoading}>
+                {scheduleLoading ? 'Saving...' : 'Create Schedule'}
+              </button>
+              <button type="button" onClick={loadActiveSchedule} disabled={scheduleLoading}>
+                {scheduleLoading ? 'Loading...' : 'Refresh Active Window'}
+              </button>
+            </div>
+          </form>
+          <StatusMessage status={scheduleStatus} />
+          <div className={styles.infoPanel}>
+            {activeSchedule ? (
+              <pre>{JSON.stringify(activeSchedule, null, 2)}</pre>
+            ) : (
+              <p className={styles.empty}>No active schedule window found.</p>
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Committee List & CRUD" subtitle="Filter by name, paginate and manage committee records.">
+          <div className={styles.filterRow}>
+            <label htmlFor="filterName">
+              Name Filter
+              <input
+                id="filterName"
+                value={filters.name}
+                onChange={(event) => setFilters((prev) => ({ ...prev, name: event.target.value, page: 1 }))}
+                placeholder="Search committee by name"
+              />
+            </label>
+            <label htmlFor="filterLimit">
+              Page Size
+              <input
+                id="filterLimit"
+                type="number"
+                min="1"
+                max="50"
+                value={filters.limit}
+                onChange={(event) => setFilters((prev) => ({ ...prev, limit: Number(event.target.value) || 10, page: 1 }))}
+              />
+            </label>
+            <button type="button" onClick={loadCommittees} disabled={committeeLoading}>
+              {committeeLoading ? 'Loading...' : 'Apply'}
+            </button>
+          </div>
+
+          <form className={styles.form} onSubmit={onSubmitCommittee}>
+            <label htmlFor="committeeName">
+              Committee Name
+              <input
+                id="committeeName"
+                value={committeeForm.name}
+                onChange={(event) => setCommitteeForm({ name: event.target.value })}
+                placeholder="e.g. AI Research Committee"
+                required
+              />
+            </label>
+            <div className={styles.inlineActions}>
+              <button type="submit" disabled={committeeLoading}>
+                {committeeLoading ? 'Saving...' : editingCommitteeId ? 'Update Committee' : 'Create Committee'}
+              </button>
+              {editingCommitteeId ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingCommitteeId(null)
+                    setCommitteeForm({ name: '' })
+                  }}
+                >
+                  Cancel Edit
+                </button>
+              ) : null}
+            </div>
+          </form>
+
+          <StatusMessage status={committeeStatus} />
+
+          {committeeMeta ? <p className={styles.meta}>{committeeMeta}</p> : null}
+          <div className={styles.list}>
+            {committeeLoading ? (
+              <p className={styles.empty}>Loading committees...</p>
+            ) : committees.length === 0 ? (
+              <p className={styles.empty}>No committees found for current filter.</p>
+            ) : (
+              committees.map((committee) => {
+                const id = committee.id || committee.committeeId
+                const name = committee.name || committee.committeeName || 'Unnamed committee'
+                return (
+                  <article key={id} className={styles.listItem}>
+                    <button
+                      type="button"
+                      className={styles.linkButton}
+                      onClick={() => setSelectedCommitteeId(id)}
+                    >
+                      {name}
+                    </button>
+                    <div className={styles.itemActions}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditingCommitteeId(id)
+                          setCommitteeForm({ name })
+                        }}
+                      >
+                        Edit
+                      </button>
+                      <button type="button" onClick={() => onDeleteCommittee(id)}>
+                        Delete
+                      </button>
+                    </div>
+                  </article>
+                )
+              })
+            )}
+          </div>
+
+          <div className={styles.inlineActions}>
+            <button
+              type="button"
+              disabled={committeeLoading || filters.page <= 1}
+              onClick={() => setFilters((prev) => ({ ...prev, page: Math.max(1, prev.page - 1) }))}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              disabled={committeeLoading || (pagination.total !== null && committees.length < filters.limit)}
+              onClick={() => setFilters((prev) => ({ ...prev, page: prev.page + 1 }))}
+            >
+              Next
+            </button>
+          </div>
+        </SectionCard>
+      </div>
+
+      <SectionCard title="Committee Details" subtitle="Jury, advisors and groups management tabs.">
+        <div className={styles.selectRow}>
+          <label htmlFor="committeeSelect">
+            Selected Committee
+            <input
+              id="committeeSelect"
+              value={selectedCommitteeId}
+              onChange={(event) => setSelectedCommitteeId(event.target.value)}
+              placeholder="Committee ID"
+            />
+          </label>
+          <button type="button" onClick={() => loadCommitteeDetails(selectedCommitteeId)} disabled={detailLoading || !selectedCommitteeId}>
+            {detailLoading ? 'Loading...' : 'Load Details'}
+          </button>
+        </div>
+
+        <StatusMessage status={detailStatus} />
+        <div className={styles.infoPanel}>
+          {selectedCommittee ? (
+            <pre>{JSON.stringify(selectedCommittee, null, 2)}</pre>
+          ) : (
+            <p className={styles.empty}>No committee selected yet.</p>
+          )}
+        </div>
+
+        <div className={styles.tabs} role="tablist" aria-label="Committee relation tabs">
+          {TAB_KEYS.map((key) => (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === key}
+              className={activeTab === key ? styles.activeTab : styles.tab}
+              onClick={() => setActiveTab(key)}
+            >
+              {key === 'jury' ? 'Jury' : key === 'advisors' ? 'Advisors' : 'Groups'}
+            </button>
+          ))}
+        </div>
+
+        <form className={styles.form} onSubmit={onAddRelation}>
+          {activeTab === 'jury' ? (
+            <label htmlFor="juryInput">
+              Jury User ID
+              <input id="juryInput" value={juryInput} onChange={(event) => setJuryInput(event.target.value)} placeholder="user id" />
+            </label>
+          ) : null}
+          {activeTab === 'advisors' ? (
+            <label htmlFor="advisorInput">
+              Advisor User ID
+              <input id="advisorInput" value={advisorInput} onChange={(event) => setAdvisorInput(event.target.value)} placeholder="advisor user id" />
+            </label>
+          ) : null}
+          {activeTab === 'groups' ? (
+            <label htmlFor="groupInput">
+              Group ID
+              <input id="groupInput" value={groupInput} onChange={(event) => setGroupInput(event.target.value)} placeholder="group id" />
+            </label>
+          ) : null}
+
+          <div className={styles.inlineActions}>
+            <button type="submit" disabled={tabLoading || !selectedCommitteeId}>
+              {tabLoading ? 'Processing...' : 'Add / Assign'}
+            </button>
+            <button type="button" onClick={() => loadTabData(selectedCommitteeId, activeTab)} disabled={tabLoading || !selectedCommitteeId}>
+              {tabLoading ? 'Loading...' : 'Refresh Tab'}
+            </button>
+          </div>
+        </form>
+
+        <StatusMessage status={tabStatus} />
+
+        <div className={styles.list}>
+          {tabLoading ? (
+            <p className={styles.empty}>Loading tab data...</p>
+          ) : activeCollection.length === 0 ? (
+            <p className={styles.empty}>No records available in this tab.</p>
+          ) : (
+            activeCollection.map((item) => {
+              const id = getRelationId(item)
+              return (
+                <article key={id} className={styles.listItem}>
+                  <pre>{JSON.stringify(item, null, 2)}</pre>
+                  <button type="button" onClick={() => onRemoveRelation(id)}>
+                    Remove
+                  </button>
+                </article>
+              )
+            })
+          )}
+        </div>
+      </SectionCard>
+    </div>
+  )
+}
+
+export default CoordinatorManagementPage

--- a/frontend/src/pages/CoordinatorManagementPage.module.css
+++ b/frontend/src/pages/CoordinatorManagementPage.module.css
@@ -1,0 +1,248 @@
+.container {
+  display: grid;
+  gap: 20px;
+}
+
+.header {
+  border: 1px solid #334155;
+  border-radius: 16px;
+  padding: 18px 20px;
+  background: linear-gradient(145deg, #0f172a, #172554);
+}
+
+.header h1 {
+  margin: 6px 0 0;
+  font-size: 24px;
+}
+
+.badge {
+  margin: 0;
+  color: #93c5fd;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.card {
+  border: 1px solid #334155;
+  border-radius: 16px;
+  padding: 16px;
+  background: #111827;
+}
+
+.cardHeader h2 {
+  margin: 0;
+  font-size: 19px;
+}
+
+.cardHeader p {
+  margin: 8px 0 0;
+  color: #94a3b8;
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.form label {
+  display: grid;
+  gap: 6px;
+  color: #e2e8f0;
+}
+
+.form input {
+  border: 1px solid #475569;
+  border-radius: 10px;
+  padding: 10px;
+  background: #020617;
+  color: #e2e8f0;
+}
+
+.form button,
+.filterRow button,
+.itemActions button,
+.listItem button,
+.selectRow button,
+.inlineActions button,
+.linkButton {
+  border: 1px solid #475569;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: #1d4ed8;
+  color: #e2e8f0;
+  cursor: pointer;
+}
+
+.form button:disabled,
+.filterRow button:disabled,
+.itemActions button:disabled,
+.listItem button:disabled,
+.selectRow button:disabled,
+.inlineActions button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.inlineActions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.statusBlock {
+  margin-top: 12px;
+  border-radius: 12px;
+  padding: 10px 12px;
+}
+
+.success {
+  background: #0b2f2b;
+  border: 1px solid #14532d;
+  color: #a7f3d0;
+}
+
+.error {
+  background: #3f1717;
+  border: 1px solid #7f1d1d;
+  color: #fecaca;
+}
+
+.infoPanel {
+  margin-top: 12px;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 10px;
+  background: #020617;
+}
+
+.infoPanel pre {
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.empty {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.filterRow {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  align-items: end;
+}
+
+.filterRow label {
+  display: grid;
+  gap: 6px;
+}
+
+.filterRow input {
+  border: 1px solid #475569;
+  border-radius: 10px;
+  padding: 10px;
+  background: #020617;
+  color: #e2e8f0;
+}
+
+.meta {
+  margin: 12px 0 0;
+  color: #93c5fd;
+}
+
+.list {
+  margin-top: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.listItem {
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 12px;
+  background: #0b1220;
+  display: grid;
+  gap: 10px;
+}
+
+.listItem pre {
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.itemActions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.linkButton {
+  width: fit-content;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: #93c5fd;
+  text-decoration: underline;
+}
+
+.selectRow {
+  display: flex;
+  gap: 10px;
+  align-items: end;
+  flex-wrap: wrap;
+}
+
+.selectRow label {
+  display: grid;
+  gap: 6px;
+  min-width: 280px;
+}
+
+.selectRow input {
+  border: 1px solid #475569;
+  border-radius: 10px;
+  padding: 10px;
+  background: #020617;
+  color: #e2e8f0;
+}
+
+.tabs {
+  display: flex;
+  gap: 10px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+
+.tab,
+.activeTab {
+  border: 1px solid #475569;
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: #0b1220;
+  color: #cbd5e1;
+  cursor: pointer;
+}
+
+.activeTab {
+  background: #1e40af;
+  color: #eff6ff;
+}
+
+@media (max-width: 1024px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .filterRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/utils/committeeService.js
+++ b/frontend/src/utils/committeeService.js
@@ -1,0 +1,125 @@
+import apiClient from './apiClient'
+import apiConfig from '../config/api'
+import { getHttpErrorDetails } from './httpErrorMessages'
+
+export async function listCommittees(params = {}) {
+  try {
+    const response = await apiClient.get(apiConfig.endpoints.committees, { params })
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to fetch committees.')
+  }
+}
+
+export async function createCommittee(payload) {
+  try {
+    const response = await apiClient.post(apiConfig.endpoints.committees, payload)
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to create committee.')
+  }
+}
+
+export async function getCommittee(committeeId) {
+  try {
+    const response = await apiClient.get(apiConfig.endpoints.committeeById(committeeId))
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to fetch committee details.')
+  }
+}
+
+export async function updateCommittee(committeeId, payload) {
+  try {
+    const response = await apiClient.patch(apiConfig.endpoints.committeeById(committeeId), payload)
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to update committee.')
+  }
+}
+
+export async function deleteCommittee(committeeId) {
+  try {
+    await apiClient.delete(apiConfig.endpoints.committeeById(committeeId))
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to delete committee.')
+  }
+}
+
+export async function listJuryMembers(committeeId) {
+  try {
+    const response = await apiClient.get(apiConfig.endpoints.committeeJuryMembers(committeeId))
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to fetch jury members.')
+  }
+}
+
+export async function addJuryMember(committeeId, userId) {
+  try {
+    const response = await apiClient.post(apiConfig.endpoints.committeeJuryMembers(committeeId), { userId })
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to add jury member.')
+  }
+}
+
+export async function removeJuryMember(committeeId, userId) {
+  try {
+    await apiClient.delete(apiConfig.endpoints.committeeJuryMemberByUser(committeeId, userId))
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to remove jury member.')
+  }
+}
+
+export async function listAdvisors(committeeId) {
+  try {
+    const response = await apiClient.get(apiConfig.endpoints.committeeAdvisors(committeeId))
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to fetch advisors.')
+  }
+}
+
+export async function addAdvisor(committeeId, advisorUserId) {
+  try {
+    const response = await apiClient.post(apiConfig.endpoints.committeeAdvisors(committeeId), { advisorUserId })
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to add advisor.')
+  }
+}
+
+export async function removeAdvisor(committeeId, advisorUserId) {
+  try {
+    await apiClient.delete(apiConfig.endpoints.committeeAdvisorByUser(committeeId, advisorUserId))
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to remove advisor.')
+  }
+}
+
+export async function listCommitteeGroups(committeeId) {
+  try {
+    const response = await apiClient.get(apiConfig.endpoints.committeeGroups(committeeId))
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to fetch assigned groups.')
+  }
+}
+
+export async function assignCommitteeGroup(committeeId, groupId) {
+  try {
+    const response = await apiClient.post(apiConfig.endpoints.committeeGroups(committeeId), { groupId })
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to assign group.')
+  }
+}
+
+export async function removeCommitteeGroup(committeeId, groupId) {
+  try {
+    await apiClient.delete(apiConfig.endpoints.committeeGroupById(committeeId, groupId))
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to remove group assignment.')
+  }
+}

--- a/frontend/src/utils/httpErrorMessages.js
+++ b/frontend/src/utils/httpErrorMessages.js
@@ -1,0 +1,29 @@
+export const DEFAULT_ERROR_MESSAGE = 'An unexpected error occurred. Please try again.'
+
+export function getHttpErrorDetails(error, fallbackMessage = DEFAULT_ERROR_MESSAGE) {
+  const status = error?.response?.status
+  const backendMessage = error?.response?.data?.message
+
+  const mappedByStatus = {
+    400: 'Request payload is invalid. Please review the form fields.',
+    401: 'Your session has expired. Please sign in again.',
+    403: 'You do not have permission to perform this action.',
+    404: 'The requested resource was not found.',
+    409: 'This action conflicts with existing committee data.',
+    422: 'This action violates a prerequisite or validation rule.',
+    423: 'This action is locked because the schedule window is closed.',
+    500: 'Server error occurred while processing your request.',
+  }
+
+  let message = fallbackMessage
+
+  if (Array.isArray(backendMessage) && backendMessage.length > 0) {
+    message = backendMessage.join(', ')
+  } else if (typeof backendMessage === 'string' && backendMessage.trim()) {
+    message = backendMessage
+  } else if (status && mappedByStatus[status]) {
+    message = mappedByStatus[status]
+  }
+
+  return { status, message }
+}

--- a/frontend/src/utils/scheduleService.js
+++ b/frontend/src/utils/scheduleService.js
@@ -1,0 +1,21 @@
+import apiClient from './apiClient'
+import apiConfig from '../config/api'
+import { getHttpErrorDetails } from './httpErrorMessages'
+
+export async function createSchedule(payload) {
+  try {
+    const response = await apiClient.post(apiConfig.endpoints.schedules, payload)
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to create schedule.')
+  }
+}
+
+export async function getActiveSchedule() {
+  try {
+    const response = await apiClient.get(apiConfig.endpoints.schedulesActive)
+    return response.data
+  } catch (error) {
+    throw getHttpErrorDetails(error, 'Unable to fetch active schedule.')
+  }
+}


### PR DESCRIPTION
FE-04 kapsamında Coordinator için tek bir management suite geliştirildi. Bu ekranda schedule oluşturma ve aktif pencere görüntüleme, committee CRUD işlemleri, committee detayında jury/advisor/group sekmeleri üzerinden listeleme-ekleme-kaldırma akışları uçtan uca desteklendi. Committee listesinde isim filtreleme ve sayfalama davranışı sağlandı.

Uygulama genelinde coordinator sayfaları için tutarlı loading/error/empty state yapısı kuruldu. 409, 422 ve 423 başta olmak üzere tüm gerekli status kodları için kullanıcıya açık ve aksiyon alınabilir hata mesajları gösterilecek şekilde ortak error mapping yaklaşımı uygulandı. Böylece conflict, prerequisite/validation ve window-closed senaryoları net biçimde yönetilebilir hale getirildi.

Bu çalışma ile FE, Process 4 schedule kontratı ve Process 5 committee/jury/advisor/group kontratıyla uyumlu hale getirildi; coordinator operasyonları tek noktadan, daha kontrollü ve demo edilebilir bir akışa taşındı.