### PR TITLE
Issues37 40 41(fix)

### DIFF
--- a/backend/src/committees/committees.controller.ts
+++ b/backend/src/committees/committees.controller.ts
@@ -341,6 +341,44 @@ export class CommitteesController {
     );
   }
 
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    operationId: 'removeGroupFromCommittee',
+    summary: 'Remove a group from a committee (COORDINATOR only)',
+  })
+  @ApiNoContentResponse({ description: 'Group removed successfully' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiForbiddenResponse({
+    description: 'Valid token but insufficient permissions',
+  })
+  @ApiNotFoundResponse({
+    description: 'Committee or group assignment not found',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Unexpected internal failure',
+  })
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(Role.Coordinator)
+  @Delete(':committeeId/groups/:groupId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeGroupFromCommittee(
+    @Param('committeeId', new ParseUUIDPipe()) committeeId: string,
+    @Param('groupId', new ParseUUIDPipe()) groupId: string,
+    @Request() req: RequestWithUser,
+  ): Promise<void> {
+    const coordinatorId =
+      req.user.userId ?? req.user.sub ?? req.user._id ?? 'unknown';
+    const correlationId =
+      (req.headers['x-correlation-id'] as string) ?? undefined;
+
+    await this.committeesService.removeGroupFromCommittee(
+      committeeId,
+      groupId,
+      coordinatorId,
+      correlationId,
+    );
+  }
+
   private toResponseDto(committee: CommitteeDocument): CommitteeResponseDto {
     return {
       id: committee.id,

--- a/backend/src/committees/committees.service.ts
+++ b/backend/src/committees/committees.service.ts
@@ -579,4 +579,56 @@ export class CommitteesService {
       );
     }
   }
+
+  async removeGroupFromCommittee(
+    committeeId: string,
+    groupId: string,
+    coordinatorId: string,
+    correlationId?: string,
+  ): Promise<void> {
+    try {
+      const committee = await this.committeeModel
+        .findOne({ id: committeeId })
+        .exec();
+      if (!committee) {
+        throw new NotFoundException(
+          `Committee with ID '${committeeId}' not found.`,
+        );
+      }
+
+      const groupExistsInCommittee = ((committee.groups as any[]) ?? []).some(
+        (group) => group.groupId === groupId,
+      );
+      if (!groupExistsInCommittee) {
+        throw new NotFoundException(
+          `Group '${groupId}' is not assigned to committee '${committeeId}'.`,
+        );
+      }
+
+      await this.committeeModel
+        .updateOne({ id: committeeId }, { $pull: { groups: { groupId } } })
+        .exec();
+
+      this.logger.log({
+        event: 'committee_group_removed',
+        committeeId,
+        groupId,
+        coordinatorId,
+        correlationId,
+      });
+    } catch (error) {
+      if (error instanceof NotFoundException) throw error;
+      this.logger.error({
+        event: 'committee_group_remove_failed',
+        committeeId,
+        groupId,
+        coordinatorId,
+        correlationId,
+        error: (error as Error).message,
+      });
+      throw new InternalServerErrorException(
+        'Failed to remove group from committee due to an unexpected error.',
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Adds a coordinator-only endpoint to remove a group from a committee (`DELETE /committees/{committeeId}/groups/{groupId}`), with consistent error mapping and logging.

Closes #[ISSUE_NUMBER]

---

## Type of Change
- [x] Feature (new endpoint or business logic)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Configuration / infrastructure
- [ ] Background job / scheduled task
- [ ] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change

**Backend:**
- Controller(s): `backend/src/committees/committees.controller.ts`
- Use case(s) / service(s): `backend/src/committees/committees.service.ts`
- Repository / DB layer: Committee model (`findOne`, `updateOne/$pull`)
- Schema / migration: None
- OpenAPI spec file(s): `docs/api/api-specs/process5.yaml` (aligned, not changed)

---

## API Contract Alignment

| Field | Value |
|---|---|
| Endpoint | `DELETE /committees/{committeeId}/groups/{groupId}` |
| OperationId | `removeGroupFromCommittee` |
| OpenAPI file | `process5.yaml` |
| Spec updated in this PR | No |

- [x] Response shape matches OpenAPI schema exactly
- [x] All documented status codes are reachable via implementation
- [x] No fields added to response that are not in the spec
- [x] groupId / actorId extracted from JWT — NOT from request body (if applicable)

---

## Test Evidence

**Unit tests:** Not added in this PR  
**Controller tests:** Not added in this PR  
**Integration / E2E tests:** Not added in this PR  

**Test file locations:**
- Unit: N/A
- Controller: N/A
- E2E: N/A

**Test run output:** Not included in this PR.

---

## Status Code Matrix Verification

| Code | Scenario | Tested |
|---|---|---|
| 204 | Happy path | ☐ |
| 400 | Validation failure | ☐ |
| 401 | Missing/invalid JWT | ☐ |
| 403 | Role mismatch | ☐ |
| 404 | Committee/group relation not found | ☐ |
| 500 | Internal/DB failure | ☐ |

---

## Observability Checklist
- [x] Key business event is logged with correlationId / requestId
- [x] No secrets/tokens/hashes/sensitive data in logs
- [x] 500 responses include actionable internal context in server logs
- [ ] Audit log entry written (depends on Issue 47)

---

## Migration / Breaking Change Assessment
- [x] No database migration required
- [x] No breaking change to API contract
- [x] Backward compatibility note: additive delete capability only

---

## Dependencies
- Requires Issue 47 (Audit logging) to be merged first: Yes (for audit-log checkbox only)

---

## Reviewer Notes
- Please focus on role guard enforcement and error mapping consistency in `removeGroupFromCommittee`.