### PR TITLE
Enforce group membership validation for submission writes

### DIFF
--- a/backend/src/auth/guards/group-member.guard.ts
+++ b/backend/src/auth/guards/group-member.guard.ts
@@ -1,4 +1,9 @@
-import { CanActivate, ExecutionContext, Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { SubmissionsService } from '../../submissions/submissions.service';
 
 @Injectable()
@@ -7,20 +12,16 @@ export class GroupMemberGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-    const user = request.user; 
+    const user = request.user;
     const submissionId = request.params.submissionId;
 
-    
     const submission = await this.submissionsService.findById(submissionId);
     if (!submission) throw new NotFoundException('Submission not found');
 
-    
-    if (user.role === 'Admin' || user.role === 'Coordinator') return true;
-
-    
-    if (user.teamId !== submission.groupId) {
-      throw new ForbiddenException('IDOR Detected: You cannot upload files to another group\'s submission.');
-    }
+    await this.submissionsService.assertAuthorizedGroupMember(
+      user,
+      submission.groupId,
+    );
 
     return true;
   }

--- a/backend/src/submissions/submissions.controller.spec.ts
+++ b/backend/src/submissions/submissions.controller.spec.ts
@@ -13,6 +13,7 @@ describe('SubmissionsController', () => {
     uploadDocument: jest.fn(),
     createSubmission: jest.fn(),
     getCompleteness: jest.fn(),
+    assertAuthorizedGroupMember: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -34,6 +35,52 @@ describe('SubmissionsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should authorize and create submission', async () => {
+      const req = { user: { userId: 'student-1', role: 'Student' } };
+      const dto = {
+        title: 'Proposal',
+        groupId: 'group-123',
+        type: 'INITIAL',
+        phaseId: 'phase-1',
+      };
+      const created = { _id: 'sub-1', ...dto };
+
+      mockSubmissionsService.assertAuthorizedGroupMember.mockResolvedValue(
+        undefined,
+      );
+      mockSubmissionsService.createSubmission.mockResolvedValue(created);
+
+      const result = await controller.create(req as any, dto);
+
+      expect(service.assertAuthorizedGroupMember).toHaveBeenCalledWith(
+        req.user,
+        dto.groupId,
+      );
+      expect(service.createSubmission).toHaveBeenCalledWith(dto);
+      expect(result).toEqual(created);
+    });
+
+    it('should throw ForbiddenException when authorization fails', async () => {
+      const req = { user: { userId: 'student-1', role: 'Student' } };
+      const dto = {
+        title: 'Proposal',
+        groupId: 'group-123',
+        type: 'INITIAL',
+        phaseId: 'phase-1',
+      };
+
+      mockSubmissionsService.assertAuthorizedGroupMember.mockRejectedValue(
+        new ForbiddenException('You are not authorized to submit for this group.'),
+      );
+
+      await expect(controller.create(req as any, dto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(service.createSubmission).not.toHaveBeenCalled();
+    });
   });
 
  describe('getCompleteness', () => {

--- a/backend/src/submissions/submissions.controller.ts
+++ b/backend/src/submissions/submissions.controller.ts
@@ -31,7 +31,14 @@ export class SubmissionsController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new submission' })
-  async create(@Body() createSubmissionDto: CreateSubmissionDto) {
+  async create(
+    @Req() req: Request & { user: any },
+    @Body() createSubmissionDto: CreateSubmissionDto,
+  ) {
+    await this.submissionsService.assertAuthorizedGroupMember(
+      req.user,
+      createSubmissionDto.groupId,
+    );
     return this.submissionsService.createSubmission(createSubmissionDto);
   }
 

--- a/backend/src/submissions/submissions.module.ts
+++ b/backend/src/submissions/submissions.module.ts
@@ -5,10 +5,16 @@ import { SubmissionsController } from './submissions.controller';
 import { PhasesModule } from '../phases/phases.module';
 import { Submission, SubmissionSchema } from './schemas/submission.schema';
 import { GroupMemberGuard } from '../auth/guards/group-member.guard';
+import { Group, GroupSchema } from '../groups/group.entity';
+import { User, UserSchema } from '../users/data/user.schema';
 
 @Module({
   imports: [
-    MongooseModule.forFeature([{ name: Submission.name, schema: SubmissionSchema }]),
+    MongooseModule.forFeature([
+      { name: Submission.name, schema: SubmissionSchema },
+      { name: Group.name, schema: GroupSchema },
+      { name: User.name, schema: UserSchema },
+    ]),
     PhasesModule,
   ],
   controllers: [SubmissionsController],

--- a/backend/src/submissions/submissions.service.spec.ts
+++ b/backend/src/submissions/submissions.service.spec.ts
@@ -1,7 +1,14 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Role } from '../auth/enums/role.enum';
+import { Group, GroupStatus } from '../groups/group.entity';
 import { PhasesService } from '../phases/phases.service';
+import { User } from '../users/data/user.schema';
 import { SubmissionsService } from './submissions.service';
 import { Submission } from './schemas/submission.schema';
 
@@ -29,11 +36,21 @@ describe('SubmissionsService', () => {
     path: jest.fn().mockReturnValue(true),
   };
 
+  const mockGroupModel = {
+    findOne: jest.fn(),
+  };
+
+  const mockUserModel = {
+    findById: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     mockSave.mockReset();
     mockSubmissionModel.mockClear();
     mockFindById.mockReset();
+    mockGroupModel.findOne.mockReset();
+    mockUserModel.findById.mockReset();
 
     phasesService = {
       findByPhaseId: jest.fn(),
@@ -45,6 +62,14 @@ describe('SubmissionsService', () => {
         {
           provide: getModelToken(Submission.name),
           useValue: mockSubmissionModel,
+        },
+        {
+          provide: getModelToken(Group.name),
+          useValue: mockGroupModel,
+        },
+        {
+          provide: getModelToken(User.name),
+          useValue: mockUserModel,
         },
         {
           provide: PhasesService,
@@ -222,6 +247,7 @@ describe('SubmissionsService', () => {
         type: 'INITIAL',
         phaseId: 'phase-1',
         documents: [{ originalName: 'doc.pdf', mimeType: 'application/pdf', uploadedAt: new Date() }],
+        get: jest.fn((field: string) => (submission as any)[field]),
       };
       const phase = {
         phaseId: 'phase-1',
@@ -252,6 +278,7 @@ describe('SubmissionsService', () => {
         type: 'INITIAL',
         phaseId: 'phase-1',
         documents: [],
+        get: jest.fn((field: string) => (submission as any)[field]),
       };
       const phase = {
         phaseId: 'phase-1',
@@ -272,6 +299,93 @@ describe('SubmissionsService', () => {
         requiredFields: ['title', 'documents'],
         phaseId: 'phase-1',
       });
+    });
+  });
+
+  describe('assertAuthorizedGroupMember', () => {
+    it('should allow admin users without membership lookup', async () => {
+      await expect(
+        service.assertAuthorizedGroupMember(
+          { userId: 'admin-id', role: Role.Admin },
+          'group-1',
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(mockGroupModel.findOne).not.toHaveBeenCalled();
+      expect(mockUserModel.findById).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when group does not exist', async () => {
+      mockGroupModel.findOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.assertAuthorizedGroupMember(
+          { userId: 'student-id', role: Role.Student },
+          'missing-group',
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when group is not active', async () => {
+      mockGroupModel.findOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          groupId: 'group-1',
+          status: GroupStatus.DISBANDED,
+        }),
+      });
+
+      await expect(
+        service.assertAuthorizedGroupMember(
+          { userId: 'student-id', role: Role.Student },
+          'group-1',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ForbiddenException when user is not in target group', async () => {
+      mockGroupModel.findOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          groupId: 'group-1',
+          status: GroupStatus.ACTIVE,
+        }),
+      });
+      mockUserModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          _id: 'student-id',
+          teamId: 'group-2',
+        }),
+      });
+
+      await expect(
+        service.assertAuthorizedGroupMember(
+          { userId: 'student-id', role: Role.Student },
+          'group-1',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow active group member', async () => {
+      mockGroupModel.findOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          groupId: 'group-1',
+          status: GroupStatus.ACTIVE,
+        }),
+      });
+      mockUserModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          _id: 'student-id',
+          teamId: 'group-1',
+        }),
+      });
+
+      await expect(
+        service.assertAuthorizedGroupMember(
+          { userId: 'student-id', role: Role.Student },
+          'group-1',
+        ),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/backend/src/submissions/submissions.service.ts
+++ b/backend/src/submissions/submissions.service.ts
@@ -1,18 +1,68 @@
 import 'multer';
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
+import { Role } from '../auth/enums/role.enum';
+import { Group, GroupDocument, GroupStatus } from '../groups/group.entity';
 import { PhasesService } from '../phases/phases.service';
+import { User, UserDocument } from '../users/data/user.schema';
 import { CreateSubmissionDto } from './dto/create-submission.dto';
 import { Submission, SubmissionDocument } from './schemas/submission.schema';
+
+type SubmissionActor = {
+  userId?: string;
+  role?: string;
+};
 
 @Injectable()
 export class SubmissionsService {
   constructor(
     @InjectModel(Submission.name)
     private submissionModel: Model<SubmissionDocument>,
+    @InjectModel(Group.name)
+    private groupModel: Model<GroupDocument>,
+    @InjectModel(User.name)
+    private userModel: Model<UserDocument>,
     private readonly phasesService: PhasesService,
   ) {}
+
+  async assertAuthorizedGroupMember(
+    actor: SubmissionActor,
+    groupId: string,
+  ): Promise<void> {
+    if (actor.role === Role.Admin || actor.role === Role.Coordinator) {
+      return;
+    }
+
+    const group = await this.groupModel.findOne({ groupId }).exec();
+    if (!group) {
+      throw new NotFoundException(`Group with ID ${groupId} not found.`);
+    }
+
+    if (group.status !== GroupStatus.ACTIVE) {
+      throw new ForbiddenException('Group is not active for submission operations.');
+    }
+
+    if (!actor.userId) {
+      throw new ForbiddenException('Authenticated user context is missing.');
+    }
+
+    const user = await this.userModel.findById(actor.userId).exec();
+    if (!user) {
+      throw new ForbiddenException('Authenticated user not found.');
+    }
+
+    if (user.teamId !== groupId) {
+      throw new ForbiddenException(
+        'You are not authorized to submit for this group.',
+      );
+    }
+  }
 
   async findById(submissionId: string): Promise<SubmissionDocument> {
     const submission = await this.submissionModel.findById(submissionId).exec();


### PR DESCRIPTION
Closes #73

## 1. PR Type
- [x] Feature: Adds new functionality or API endpoint.
- [ ] Bug Fix: Resolves an identified issue or bug.
- [ ] Chore: Routine tasks, deleting unused files, or dependency updates.
- [ ] Refactor: Code restructuring without changing behavior.
- [ ] Documentation: Updates to docs/ or README.

## 2. Purpose & Description
**Problem Statement:**
Submission write operations did not consistently enforce server-side group membership checks based on active group participation, allowing potential unauthorized submission actions.

**Changes Made:**
- Added a centralized membership authorization method in SubmissionsService to validate write permissions.
- Enforced 404 Not Found when target groupId does not exist.
- Enforced 403 Forbidden when group is inactive or requester is not a member of the target group.
- Integrated the authorization check into POST /submissions creation flow.
- Updated GroupMemberGuard for POST /submissions/:submissionId/documents to reuse the same centralized validation.
- Updated SubmissionsModule model providers to include group and user models required by the new checks.
- Added/updated unit tests for controller and service authorization paths.

**Related Issue:** Closes #73

## 3. Testing & Verification
**What Was Tested:**
- New service-level membership validator behavior for admin/coordinator bypass, missing group, inactive group, non-member, and valid member scenarios.
- Controller create flow to ensure authorization is invoked and submission creation is blocked on forbidden access.
- Existing submissions completeness unit tests after updates.

**Verification Steps (How to test):**
1. Run backend lint checks.
2. Run submissions unit tests for controller and service.

**Proof of Verification:**
- **API/Backend:** Authorization paths now return 404 for unknown groupId and 403 for unauthorized/inactive membership scenarios in service/controller logic.
- **Frontend/UI:** N/A (backend security-layer change only).
- **Unit/E2E Tests:**
  - npm run lint (backend) passed
  - npx jest src/submissions/submissions.service.spec.ts src/submissions/submissions.controller.spec.ts passed (31 tests, 2 suites)
- **Chore/Refactor:** N/A

## 4. Strict Checklist
- [x] My PR targets the main branch.
- [x] I have updated related API/System documentation if applicable.
- [x] I have kept the changes strictly focused on the stated purpose.

## 5. Executive Summary
**Summary:**
This PR adds strict server-side authorization for submission write operations by validating the requester membership against the target group. It ensures missing groups return 404 and unauthorized/inactive participants receive 403, matching the issue acceptance criteria. The update is covered with focused unit tests and passes backend lint and submissions test verification.