### PR TITLE
Fix(frontend)/issue 183 add professor feature ıs completely non functional password field missing from request

### DIFF
--- a/backend/src/submissions/submissions.service.ts
+++ b/backend/src/submissions/submissions.service.ts
@@ -120,6 +120,7 @@ export class SubmissionsService {
       message: 'Document uploaded and linked successfully',
       document: newDocument,
     };
+  }
   async findOne(id: string): Promise<SubmissionDocument> {
     return this.findById(id);
   }

--- a/frontend/src/components/ProfessorForm.jsx
+++ b/frontend/src/components/ProfessorForm.jsx
@@ -9,9 +9,17 @@ import styles from './ProfessorForm.module.css';
 const ROLES = ['Professor'];
 
 const professorSchema = z.object({
-  name: z.string({ message: 'Name is required' }).min(2).max(100),
   email: z.string({ message: 'Email is required' }).email('Invalid email address'),
-  role: z.string({ message: 'Role is required' }).refine((val) => ROLES.includes(val), 'Invalid role selected'),
+  password: z
+    .string({ message: 'Password is required' })
+    .min(8, 'Password must be at least 8 characters long')
+    .max(128, 'Password must not exceed 128 characters')
+    .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+    .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+    .regex(/[0-9]/, 'Password must contain at least one number'),
+  role: z
+    .string({ message: 'Role is required' })
+    .refine((val) => ROLES.includes(val), 'Invalid role selected'),
 });
 
 export function ProfessorForm() {
@@ -26,7 +34,7 @@ export function ProfessorForm() {
   } = useForm({
     resolver: zodResolver(professorSchema),
     mode: 'onBlur',
-    defaultValues: { name: '', email: '', role: '' },
+    defaultValues: { email: '', password: '', role: '' },
   });
 
   const onSubmit = async (data) => {
@@ -34,9 +42,9 @@ export function ProfessorForm() {
     setApiError('');
 
     try {
-      await authService.registerProfessor(data.name, data.email, data.role);
+      await authService.registerProfessor(data.email, data.password, data.role);
       reset();
-      toast.success(`Professor ${data.name} created successfully.`);
+      toast.success('Professor created successfully.');
     } catch (error) {
       const message = error.message || 'Failed to create professor.';
       setApiError(message);
@@ -62,22 +70,52 @@ export function ProfessorForm() {
 
         <form onSubmit={handleSubmit(onSubmit)} className={styles.form} noValidate>
           <div className={styles.formGroup}>
-            <label htmlFor="name" className={styles.label}>Professor Name *</label>
-            <input id="name" type="text" className={`${styles.input} ${errors.name ? styles.inputError : ''}`} {...register('name')} disabled={isSubmitting} />
-            {errors.name && <span className={styles.errorText}>{errors.name.message}</span>}
-          </div>
-
-          <div className={styles.formGroup}>
-            <label htmlFor="email" className={styles.label}>Email *</label>
-            <input id="email" type="email" className={`${styles.input} ${errors.email ? styles.inputError : ''}`} {...register('email')} disabled={isSubmitting} />
+            <label htmlFor="email" className={styles.label}>
+              Email *
+            </label>
+            <input
+              id="email"
+              type="email"
+              className={`${styles.input} ${errors.email ? styles.inputError : ''}`}
+              {...register('email')}
+              disabled={isSubmitting}
+            />
             {errors.email && <span className={styles.errorText}>{errors.email.message}</span>}
           </div>
 
           <div className={styles.formGroup}>
-            <label htmlFor="role" className={styles.label}>Role *</label>
-            <select id="role" className={`${styles.select} ${errors.role ? styles.inputError : ''}`} {...register('role')} disabled={isSubmitting}>
+            <label htmlFor="password" className={styles.label}>
+              Password *
+            </label>
+            <input
+              id="password"
+              type="password"
+              className={`${styles.input} ${errors.password ? styles.inputError : ''}`}
+              {...register('password')}
+              disabled={isSubmitting}
+              autoComplete="new-password"
+            />
+            {errors.password && (
+              <span className={styles.errorText}>{errors.password.message}</span>
+            )}
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="role" className={styles.label}>
+              Role *
+            </label>
+            <select
+              id="role"
+              className={`${styles.select} ${errors.role ? styles.inputError : ''}`}
+              {...register('role')}
+              disabled={isSubmitting}
+            >
               <option value="">Select role</option>
-              {ROLES.map((role) => <option key={role} value={role}>{role}</option>)}
+              {ROLES.map((role) => (
+                <option key={role} value={role}>
+                  {role}
+                </option>
+              ))}
             </select>
             {errors.role && <span className={styles.errorText}>{errors.role.message}</span>}
           </div>

--- a/frontend/src/components/ProfessorForm.test.jsx
+++ b/frontend/src/components/ProfessorForm.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import ProfessorForm from './ProfessorForm';
+import { ProfessorForm } from './ProfessorForm';
 import apiClient from '../utils/apiClient';
 
 vi.mock('../utils/apiClient');

--- a/frontend/src/components/ProfessorForm.test.jsx
+++ b/frontend/src/components/ProfessorForm.test.jsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ProfessorForm from './ProfessorForm';
+import apiClient from '../utils/apiClient';
+
+vi.mock('../utils/apiClient');
+
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('ProfessorForm smoke tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits valid professor registration payload', async () => {
+    apiClient.post.mockResolvedValueOnce({
+      data: { id: '1', email: 'prof@example.com', role: 'Professor' },
+    });
+
+    render(<ProfessorForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'prof@example.com' },
+    });
+
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'StrongPass1' },
+    });
+
+    fireEvent.change(screen.getByLabelText(/role/i), {
+      target: { value: 'Professor' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create professor/i }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith('/auth/admin/professors', {
+        email: 'prof@example.com',
+        password: 'StrongPass1',
+        role: 'Professor',
+      });
+    });
+
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows inline error and does not call API when password is weak', async () => {
+    render(<ProfessorForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'prof@example.com' },
+    });
+
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'abc' }, // short password
+    });
+
+    fireEvent.change(screen.getByLabelText(/role/i), {
+      target: { value: 'Professor' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create professor/i }));
+
+    
+    expect(await screen.findByText(/at least 8 characters/i)).toBeTruthy(); // should show the error message
+    
+    expect(apiClient.post).not.toHaveBeenCalled(); // no request should be made
+  });
+});

--- a/frontend/src/utils/authService.js
+++ b/frontend/src/utils/authService.js
@@ -33,20 +33,22 @@ export const authService = {
     }
   },
 
-  async registerProfessor(name, email, role) {
+  async registerProfessor(email, password, role) {
     try {
       const response = await apiClient.post(apiConfig.endpoints.adminProfessors, {
-        name,
         email,
+        password,
         role,
       });
       return response.data;
     } catch (error) {
+      const msg = error.response?.data?.message;
       const errorMessage =
-        error.response?.data?.message ||
+        (Array.isArray(msg) ? msg.join(', ') : msg) ||
         error.response?.data?.error ||
         error.message ||
         'Professor creation failed';
+
       throw new Error(errorMessage);
     }
   },


### PR DESCRIPTION
## 1. PR Type
- [ ] Feature: Adds new functionality or API endpoint.
- [x] Bug Fix: Resolves an identified issue or bug.
- [ ] Chore: Routine tasks, deleting unused files, or dependency updates.
- [ ] Refactor: Code restructuring without changing behavior.
- [ ] Documentation: Updates to docs/ or README.

## 2. Purpose & Description
**Problem Statement:**
Professor creation from the admin page failed because frontend sent `{ name, email, role }` while backend `CreateProfessorDto` requires `{ email, password, role }`. The `name` field was not part of backend DTO/schema and was silently discarded by whitelist validation.

**Changes Made:**
- Removed `name` from `ProfessorForm` and form payload.
- Added `password` field to `ProfessorForm` UI.
- Added frontend password validation matching backend rules:
  - minimum 8 characters
  - at least one uppercase letter
  - at least one lowercase letter
  - at least one number
- Updated `authService.registerProfessor(...)` to send `{ email, password, role }`.
- Improved frontend API error handling to display readable messages.
- Added smoke tests for professor registration:
  - valid payload submits successfully
  - weak/missing password blocks submit before API call

**Related Issue:** #183 

## 3. Testing & Verification
**What Was Tested:**
- Professor registration happy path from form submit.
- Password client-side validation behavior.
- Request payload shape sent to `/auth/admin/professors`.
- API error display behavior (including validation/duplicate-like responses).

**Verification Steps (How to test):**
1. Run frontend tests:
   - `cd frontend`
   - `npx vitest run src/components/ProfessorForm.test.jsx`
2. Manual UI verification:
   - Open Add Professor page.
   - Submit with weak password and confirm inline validation appears and no request is sent.
   - Submit with valid `email + password + role` and confirm request succeeds (201 from backend if authorized coordinator).

**Proof of Verification:**
- **API/Backend:** Endpoint contract used: `POST /api/v1/auth/admin/professors` with `{ email, password, role }`.
- **Frontend/UI:** Form now shows inline password validation and no longer includes `name` field.
- **Unit/E2E Tests:** `ProfessorForm` smoke tests pass for both happy path and invalid password path.
- **Chore/Refactor:** N/A

## 4. Strict Checklist
- [x] My PR targets the `main` branch.
- [ ] I have updated related API/System documentation if applicable.
- [x] I have kept the changes strictly focused on the stated purpose.

## 5. Executive Summary
**Summary:**
This PR fixes professor registration by aligning frontend payload and validation with backend `CreateProfessorDto`. It removes the unused `name` field and introduces required password input with matching complexity rules. Smoke tests were added to prevent regressions in payload contract and client-side validation.