### PR TITLE
Fix routing for document submissions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,9 +54,10 @@ function App() {
             <Route path="/dashboard" element={<DashboardPage />} />
                        <Route path="/groups" element={<StudentGroupManagementPage />} />
             <Route path="/all-groups" element={<StudentGroupManagementPage />} />
+            <Route path="/documents/upload" element={<StudentSubmissionPage />} />
             <Route path="/documents/:phaseId/:submissionId" element={<StudentSubmissionPage />} />
             <Route path="/documents/:id" element={<SubmissionDetailsPage />} />
-            <Route path="/documents" element={<StudentSubmissionPage />} />
+            <Route path="/documents" element={<DocumentsPage />} />
             <Route path="/coordinator-management" element={<CoordinatorManagementPage />} />
             <Route
               path="/phases/schedule"

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Outlet } from 'react-router-dom';
+import App from './App';
+
+vi.mock('./context/AuthContext', () => ({
+  AuthProvider: ({ children }) => children,
+  useAuth: () => ({ isAuthenticated: true }),
+}));
+
+vi.mock('./components/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }) => children,
+}));
+
+vi.mock('./components/layout/Layout', () => ({
+  Layout: () => <Outlet />,
+}));
+
+vi.mock('./pages/DocumentsPage', () => ({
+  default: () => <div>Documents List Page</div>,
+}));
+
+vi.mock('./pages/StudentSubmissionPage', () => ({
+  default: () => <div>Student Upload Page</div>,
+}));
+
+vi.mock('./pages/SubmissionDetailsPage', () => ({
+  default: () => <div>Submission Details Page</div>,
+}));
+
+vi.mock('./pages/StudentGroupManagementPage', () => ({
+  default: () => <div>Student Group Management Page</div>,
+}));
+
+vi.mock('./pages/CoordinatorManagementPage', () => ({
+  default: () => <div>Coordinator Management Page</div>,
+}));
+
+vi.mock('./pages/RegisterPage', () => ({
+  default: () => <div>Register Page</div>,
+}));
+
+vi.mock('./pages/LoginPage', () => ({
+  default: () => <div>Login Page</div>,
+}));
+
+vi.mock('./pages/DashboardPage', () => ({
+  default: () => <div>Dashboard Page</div>,
+}));
+
+vi.mock('./pages/PhaseSchedulingPage', () => ({
+  default: () => <div>Phase Scheduling Page</div>,
+}));
+
+vi.mock('./pages/ForgotPasswordPage', () => ({
+  ForgotPasswordPage: () => <div>Forgot Password Page</div>,
+}));
+
+vi.mock('./pages/ResetPasswordPage', () => ({
+  ResetPasswordPage: () => <div>Reset Password Page</div>,
+}));
+
+vi.mock('./components/AdminLayout', () => ({
+  default: () => <Outlet />,
+}));
+
+vi.mock('./pages/admin/GroupsPage', () => ({
+  default: () => <div>Admin Groups Page</div>,
+}));
+
+vi.mock('./pages/admin/MembersPage', () => ({
+  default: () => <div>Admin Members Page</div>,
+}));
+
+vi.mock('./pages/admin/InvitesPage', () => ({
+  default: () => <div>Admin Invites Page</div>,
+}));
+
+vi.mock('./pages/admin/AdvisorsPage', () => ({
+  default: () => <div>Admin Advisors Page</div>,
+}));
+
+vi.mock('./pages/admin/ProfessorPage', () => ({
+  default: () => <div>Admin Professors Page</div>,
+}));
+
+vi.mock('./pages/admin/SanitizationPage', () => ({
+  default: () => <div>Admin Sanitization Page</div>,
+}));
+
+vi.mock('./pages/admin/ActivityPage', () => ({
+  default: () => <div>Admin Activity Page</div>,
+}));
+
+describe('App document routes', () => {
+  it('renders the documents list at /documents', () => {
+    window.history.pushState({}, '', '/documents');
+
+    render(<App />);
+
+    expect(screen.getByText('Documents List Page')).toBeTruthy();
+  });
+
+  it('renders the upload form at /documents/upload', () => {
+    window.history.pushState({}, '', '/documents/upload');
+
+    render(<App />);
+
+    expect(screen.getByText('Student Upload Page')).toBeTruthy();
+  });
+
+  it('renders submission details at /documents/:id', () => {
+    window.history.pushState({}, '', '/documents/submission-123');
+
+    render(<App />);
+
+    expect(screen.getByText('Submission Details Page')).toBeTruthy();
+  });
+});

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -29,6 +29,8 @@ export const apiConfig = {
     advisorValidation: '/admin/advisor-validation',
     sanitizationExecute: '/admin/sanitization/execute',
     submissions: {
+      list: '/submissions',
+      byGroup: (groupId) => `/submissions?groupId=${groupId}`,
       mine: '/submissions/me',
       uploadDocument: (submissionId) => `/submissions/${submissionId}/documents`,
     },

--- a/frontend/src/pages/DocumentsPage.jsx
+++ b/frontend/src/pages/DocumentsPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import apiClient from '../utils/apiClient';
+import apiConfig from '../config/api';
 import styles from './DocumentsPage.module.css';
 import { useNavigate } from 'react-router-dom';
 
@@ -19,7 +20,7 @@ const DocumentsPage = () => {
           return;
         }
 
-        let endpoint = '/submissions';
+        let endpoint = apiConfig.endpoints.submissions.list;
         const userGroupId = localUser.teamId || localUser.groupId;
 
         if (localUser.role === 'Student') {
@@ -30,7 +31,7 @@ const DocumentsPage = () => {
             });
             return;
           }
-          endpoint += `?groupId=${userGroupId}`;
+          endpoint = apiConfig.endpoints.submissions.byGroup(userGroupId);
         } else if (localUser.role !== 'Coordinator') {
           setStatus({ loading: false, error: 'Unrecognized user role. Access denied.' });
           return;

--- a/frontend/src/pages/DocumentsPage.test.jsx
+++ b/frontend/src/pages/DocumentsPage.test.jsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import DocumentsPage from './DocumentsPage';
 import apiClient from '../utils/apiClient';
+import apiConfig from '../config/api';
 
 // 1. Mock the apiClient to prevent real network requests
 vi.mock('../utils/apiClient');
@@ -74,7 +75,7 @@ describe('DocumentsPage Component', () => {
     expect(screen.getByText('Approved')).toBeTruthy();
     
     // Check if the API was called with the correct query parameter
-    expect(apiClient.get).toHaveBeenCalledWith('/submissions?groupId=group-123');
+    expect(apiClient.get).toHaveBeenCalledWith(apiConfig.endpoints.submissions.byGroup('group-123'));
   });
 
   it('should show an error message if the user session is missing', async () => {
@@ -103,6 +104,22 @@ describe('DocumentsPage Component', () => {
     await waitFor(() => {
       expect(screen.getByText(/No submissions found/i)).toBeTruthy();
     });
+  });
+
+  it('should show a friendly error when a student has no group assigned', async () => {
+    localStorage.setItem('user', JSON.stringify({ role: 'Student' }));
+
+    render(
+      <BrowserRouter>
+        <DocumentsPage />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/You are not assigned to any group yet/i)).toBeTruthy();
+    });
+
+    expect(apiClient.get).not.toHaveBeenCalled();
   });
 
   it('should navigate to details page when "View Details" is clicked', async () => {


### PR DESCRIPTION
## 1. PR Type
- [ ] Feature: Adds new functionality or API endpoint.
- [x] Bug Fix: Resolves an identified issue or bug.
- [ ] Chore: Routine tasks, deleting unused files, or dependency updates.
- [ ] Refactor: Code restructuring without changing behavior.
- [ ] Documentation: Updates to docs/ or README.

## 2. Purpose & Description
**Problem Statement:**
Issue #181 reports that the submission system routing is broken. `/documents` is bound to the upload form instead of the document list, which makes `DocumentsPage` unreachable from the UI and causes "Back to List" from submission details to return users to the upload form.

**Changes Made:**
- Registered `DocumentsPage` at `/documents`.
- Added `/documents/upload` as the dedicated upload form route.
- Preserved the existing `/documents/:phaseId/:submissionId` upload route.
- Kept `/documents/:id` as the submission detail route.
- Updated `DocumentsPage` to use `apiConfig.endpoints.submissions` instead of raw `/submissions` strings.
- Added route-level tests for document list, upload, and detail routing.
- Added coverage for the friendly no-group-assigned student error.

**Related Issue:** #181  
Closes #181

## 3. Testing & Verification
**What Was Tested:**
- Frontend document routing for list, upload, and detail pages.
- Frontend documents list behavior.
- Frontend submission details behavior.
- Friendly error handling when a student has no assigned group.

**Verification Steps (How to test):**
1. Run targeted frontend tests:
   cd frontend
   npm.cmd exec vitest run src/App.test.jsx src/pages/DocumentsPage.test.jsx src/pages/SubmissionDetailsPage.test.jsx
2. Navigate to `/documents` and verify the submissions list is shown.
3. Navigate to `/documents/upload` and verify the upload form is shown.
4. Navigate to `/documents/<submissionId>` and verify the detail page is shown.

**Proof of Verification:**
- **API/Backend:**
Not applicable. No backend API behavior changed.

- **Frontend/UI:**
Route behavior is covered by `frontend/src/App.test.jsx`.

- **Unit/E2E Tests:**
Targeted frontend test run passed:
3 test files passed.
15 tests passed.

Command:
cd frontend
npm.cmd exec vitest run src/App.test.jsx src/pages/DocumentsPage.test.jsx src/pages/SubmissionDetailsPage.test.jsx

- **Chore/Refactor:**
Not applicable.

## 4. Strict Checklist
- [x] My PR targets the `main` branch.
- [x] I have updated related API/System documentation if applicable.
- [x] I have kept the changes strictly focused on the stated purpose.

## 5. Executive Summary
**Summary:** This PR fixes the broken submission routing by making `/documents` render the submission list and moving uploads to `/documents/upload`. It preserves existing detail and prefilled upload routes while centralizing submission list endpoints through `apiConfig`. The targeted frontend tests pass and cover the corrected routing plus the no-group student error case.
