### PR TITLE
Fix phase scheduling UI

### DIFF
--- a/backend/src/phases/phases.controller.ts
+++ b/backend/src/phases/phases.controller.ts
@@ -13,6 +13,12 @@ import { UpdatePhaseScheduleDto } from './dto/update-phase-schedule.dto';
 export class PhasesController {
   constructor(private readonly phasesService: PhasesService) {}
 
+  @Get()
+  @Roles(Role.Coordinator)
+  async listPhases() {
+    return this.phasesService.listForScheduling();
+  }
+
   @Get(':phaseId')
   @Roles(Role.Student, Role.Professor, Role.Coordinator, Role.Admin)
   async getPhase(@Param('phaseId') phaseId: string) {

--- a/backend/src/phases/phases.service.ts
+++ b/backend/src/phases/phases.service.ts
@@ -14,6 +14,14 @@ export class PhasesService {
     @InjectModel(Phase.name) private phaseModel: Model<PhaseDocument>,
   ) {}
 
+  async listForScheduling(): Promise<Phase[]> {
+    return this.phaseModel
+      .find()
+      .select('phaseId submissionStart submissionEnd -_id')
+      .sort({ phaseId: 1 })
+      .exec();
+  }
+
   async findByPhaseId(phaseId: string): Promise<Phase> {
     const phase = await this.phaseModel.findOne({ phaseId }).exec();
     if (!phase) {

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -16,6 +16,7 @@ export const apiConfig = {
     },
     groups: '/groups',
     groupMembers: (groupId) => `/groups/${groupId}/members`,
+    phases: '/phases',
     phaseById: (phaseId) => `/phases/${phaseId}`,
     submissionDocuments: (submissionId) => `/submissions/${submissionId}/documents`,
     groupCommittee: (groupId) => `/groups/${groupId}/committee`,

--- a/frontend/src/pages/PhaseSchedulingPage.jsx
+++ b/frontend/src/pages/PhaseSchedulingPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import apiClient from '../utils/apiClient';
 import apiConfig from '../config/api';
 import styles from './PhaseSchedulingPage.module.css';
@@ -8,50 +8,132 @@ const toLocalInputValue = (date) => {
   return new Date(date.getTime() - tzOffset).toISOString().slice(0, 16);
 };
 
-const getTomorrowLocalInputValue = () => {
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  return toLocalInputValue(tomorrow);
+const toInputValue = (value) => {
+  if (!value) return '';
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '' : toLocalInputValue(date);
 };
 
-const defaultSubmissionStart = toLocalInputValue(new Date());
-const defaultSubmissionEnd = getTomorrowLocalInputValue();
+const formatDisplayDate = (value) => {
+  if (!value) return 'Not scheduled';
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Invalid date' : date.toLocaleString();
+};
+
+const formatErrorMessages = (message) => {
+  if (Array.isArray(message)) return message;
+  if (typeof message === 'string' && message.trim()) return [message];
+  return ['Failed to update phase schedule.'];
+};
 
 function PhaseSchedulingPage() {
+  const [phases, setPhases] = useState([]);
   const [phaseId, setPhaseId] = useState('');
-  const [submissionStart, setSubmissionStart] = useState(defaultSubmissionStart);
-  const [submissionEnd, setSubmissionEnd] = useState(defaultSubmissionEnd);
+  const [submissionStart, setSubmissionStart] = useState('');
+  const [submissionEnd, setSubmissionEnd] = useState('');
   const [result, setResult] = useState(null);
-  const [status, setStatus] = useState({ loading: false, message: '', error: '' });
+  const [status, setStatus] = useState({ loading: false, loadingPhases: true, message: '', errors: [] });
+  const [fieldErrors, setFieldErrors] = useState({});
+
+  const selectedPhase = useMemo(
+    () => phases.find((phase) => phase.phaseId === phaseId) || null,
+    [phaseId, phases],
+  );
+
+  useEffect(() => {
+    const fetchPhases = async () => {
+      setStatus({ loading: false, loadingPhases: true, message: '', errors: [] });
+
+      try {
+        const response = await apiClient.get(apiConfig.endpoints.phases);
+        setPhases(response.data || []);
+        setStatus({ loading: false, loadingPhases: false, message: '', errors: [] });
+      } catch (error) {
+        const details = error.response?.data?.message || error.message;
+        setStatus({
+          loading: false,
+          loadingPhases: false,
+          message: '',
+          errors: formatErrorMessages(details || 'Failed to load phases.'),
+        });
+      }
+    };
+
+    fetchPhases();
+  }, []);
 
   const parseDateTime = (value) => new Date(value);
+
+  const applyPhaseSchedule = (phase) => {
+    setSubmissionStart(toInputValue(phase?.submissionStart));
+    setSubmissionEnd(toInputValue(phase?.submissionEnd));
+    setResult(null);
+    setFieldErrors({});
+    setStatus((current) => ({ ...current, message: '', errors: [] }));
+  };
+
+  const handlePhaseChange = (event) => {
+    const nextPhaseId = event.target.value;
+    const nextPhase = phases.find((phase) => phase.phaseId === nextPhaseId);
+
+    setPhaseId(nextPhaseId);
+    applyPhaseSchedule(nextPhase);
+  };
+
+  const validateForm = () => {
+    const nextFieldErrors = {};
+
+    if (!phaseId) {
+      nextFieldErrors.phaseId = 'Please select a phase.';
+    }
+
+    if (!submissionStart) {
+      nextFieldErrors.submissionStart = 'Submission start is required.';
+    }
+
+    if (!submissionEnd) {
+      nextFieldErrors.submissionEnd = 'Submission end is required.';
+    }
+
+    const startDate = parseDateTime(submissionStart);
+    const endDate = parseDateTime(submissionEnd);
+
+    if (submissionStart && Number.isNaN(startDate.getTime())) {
+      nextFieldErrors.submissionStart = 'Please enter a valid submission start date.';
+    }
+
+    if (submissionEnd && Number.isNaN(endDate.getTime())) {
+      nextFieldErrors.submissionEnd = 'Please enter a valid submission end date.';
+    }
+
+    if (
+      !Number.isNaN(startDate.getTime()) &&
+      !Number.isNaN(endDate.getTime()) &&
+      endDate <= startDate
+    ) {
+      nextFieldErrors.submissionEnd =
+        'Submission end date must be strictly after the submission start date.';
+    }
+
+    setFieldErrors(nextFieldErrors);
+    return Object.keys(nextFieldErrors).length === 0;
+  };
 
   const handleSubmit = async (event) => {
     event.preventDefault();
     setResult(null);
 
+    if (!validateForm()) {
+      setStatus((current) => ({ ...current, message: '', errors: [] }));
+      return;
+    }
+
     const startDate = parseDateTime(submissionStart);
     const endDate = parseDateTime(submissionEnd);
 
-    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
-      setStatus({
-        loading: false,
-        message: '',
-        error: 'Please enter valid submission start and end dates.',
-      });
-      return;
-    }
-
-    if (endDate <= startDate) {
-      setStatus({
-        loading: false,
-        message: '',
-        error: 'Submission end date must be strictly after the submission start date.',
-      });
-      return;
-    }
-
-    setStatus({ loading: true, message: '', error: '' });
+    setStatus({ loading: true, loadingPhases: false, message: '', errors: [] });
 
     try {
       const response = await apiClient.put(apiConfig.endpoints.phaseSchedule(phaseId), {
@@ -60,10 +142,22 @@ function PhaseSchedulingPage() {
       });
 
       setResult(response.data);
+      setPhases((currentPhases) =>
+        currentPhases.map((phase) =>
+          phase.phaseId === phaseId
+            ? {
+                ...phase,
+                submissionStart: response.data.submissionStart,
+                submissionEnd: response.data.submissionEnd,
+              }
+            : phase,
+        ),
+      );
       setStatus({
         loading: false,
+        loadingPhases: false,
         message: `Phase ${phaseId} schedule updated successfully.`,
-        error: '',
+        errors: [],
       });
     } catch (error) {
       const details =
@@ -71,41 +165,76 @@ function PhaseSchedulingPage() {
         error.message ||
         'Failed to update phase schedule.';
 
-      setStatus({ loading: false, message: '', error: details });
+      setStatus({ loading: false, loadingPhases: false, message: '', errors: formatErrorMessages(details) });
     }
+  };
+
+  const handleReset = () => {
+    applyPhaseSchedule(selectedPhase);
   };
 
   return (
     <div className={styles.pageContainer}>
       <header className={styles.header}>
-        <p className={styles.badge}>Issue #78</p>
-        <h1>Phase Scheduling Form</h1>
+        <p className={styles.badge}>Coordinator Tools</p>
+        <h1>Phase Scheduling</h1>
         <p className={styles.lead}>
-          Configure submission window dates for a phase using the coordinator scheduling endpoint.
+          Select a phase, review its current submission window, and update the schedule.
         </p>
       </header>
 
       <section className={styles.card}>
         <form className={styles.form} onSubmit={handleSubmit}>
           <label>
-            Phase ID
-            <input
-              type="text"
+            Phase
+            <select
               value={phaseId}
-              onChange={(e) => setPhaseId(e.target.value)}
-              placeholder="Phase UUID"
-              required
-            />
+              onChange={handlePhaseChange}
+              disabled={status.loadingPhases}
+              aria-invalid={Boolean(fieldErrors.phaseId)}
+            >
+              <option value="">
+                {status.loadingPhases ? 'Loading phases...' : 'Select a phase'}
+              </option>
+              {phases.map((phase) => (
+                <option key={phase.phaseId} value={phase.phaseId}>
+                  {phase.phaseId}
+                </option>
+              ))}
+            </select>
+            {fieldErrors.phaseId && <span className={styles.fieldError}>{fieldErrors.phaseId}</span>}
           </label>
+
+          {selectedPhase && (
+            <div className={styles.previewBox}>
+              <strong>Current Schedule</strong>
+              <dl>
+                <div>
+                  <dt>Submission Start</dt>
+                  <dd>{formatDisplayDate(selectedPhase.submissionStart)}</dd>
+                </div>
+                <div>
+                  <dt>Submission End</dt>
+                  <dd>{formatDisplayDate(selectedPhase.submissionEnd)}</dd>
+                </div>
+              </dl>
+            </div>
+          )}
 
           <label>
             Submission Start
             <input
               type="datetime-local"
               value={submissionStart}
-              onChange={(e) => setSubmissionStart(e.target.value)}
-              required
+              onChange={(event) => {
+                setSubmissionStart(event.target.value);
+                setFieldErrors((current) => ({ ...current, submissionStart: '' }));
+              }}
+              aria-invalid={Boolean(fieldErrors.submissionStart)}
             />
+            {fieldErrors.submissionStart && (
+              <span className={styles.fieldError}>{fieldErrors.submissionStart}</span>
+            )}
           </label>
 
           <label>
@@ -114,18 +243,41 @@ function PhaseSchedulingPage() {
               type="datetime-local"
               value={submissionEnd}
               min={submissionStart}
-              onChange={(e) => setSubmissionEnd(e.target.value)}
-              required
+              onChange={(event) => {
+                setSubmissionEnd(event.target.value);
+                setFieldErrors((current) => ({ ...current, submissionEnd: '' }));
+              }}
+              aria-invalid={Boolean(fieldErrors.submissionEnd)}
             />
+            {fieldErrors.submissionEnd && (
+              <span className={styles.fieldError}>{fieldErrors.submissionEnd}</span>
+            )}
           </label>
 
-          <button type="submit" disabled={status.loading}>
-            {status.loading ? 'Updating…' : 'Update Phase Schedule'}
-          </button>
+          <div className={styles.actions}>
+            <button type="submit" disabled={status.loading || !phaseId}>
+              {status.loading ? 'Updating...' : 'Update Phase Schedule'}
+            </button>
+            <button type="button" onClick={handleReset} disabled={!phaseId || status.loading} className={styles.secondaryButton}>
+              Reset
+            </button>
+          </div>
         </form>
 
         {status.message && <div className={`${styles.status} ${styles.success}`}>{status.message}</div>}
-        {status.error && <div className={`${styles.status} ${styles.error}`}>{status.error}</div>}
+        {status.errors.length > 0 && (
+          <div className={`${styles.status} ${styles.error}`}>
+            {status.errors.length === 1 ? (
+              status.errors[0]
+            ) : (
+              <ul className={styles.errorList}>
+                {status.errors.map((errorMessage) => (
+                  <li key={errorMessage}>{errorMessage}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
 
         {result && (
           <div className={styles.resultBox}>

--- a/frontend/src/pages/PhaseSchedulingPage.module.css
+++ b/frontend/src/pages/PhaseSchedulingPage.module.css
@@ -49,7 +49,8 @@
   font-weight: 600;
 }
 
-.form input {
+.form input,
+.form select {
   background: #020617;
   border: 1px solid #334155;
   border-radius: 8px;
@@ -57,13 +58,25 @@
   padding: 10px 12px;
 }
 
-.form input:focus {
+.form input:focus,
+.form select:focus {
   outline: none;
   border-color: #38bdf8;
   box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
 }
 
-.form button {
+.form input[aria-invalid='true'],
+.form select[aria-invalid='true'] {
+  border-color: #f87171;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.actions button {
   align-self: flex-start;
   border: none;
   border-radius: 8px;
@@ -74,9 +87,53 @@
   cursor: pointer;
 }
 
-.form button:disabled {
+.actions button:disabled {
   opacity: 0.7;
   cursor: not-allowed;
+}
+
+.secondaryButton {
+  background: #1e293b !important;
+  color: #e2e8f0 !important;
+}
+
+.fieldError {
+  color: #fca5a5;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.previewBox {
+  border: 1px solid #334155;
+  background: #020617;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.previewBox strong {
+  color: #e2e8f0;
+}
+
+.previewBox dl {
+  display: grid;
+  gap: 10px;
+  margin: 12px 0 0;
+}
+
+.previewBox div {
+  display: grid;
+  gap: 4px;
+}
+
+.previewBox dt {
+  color: #94a3b8;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.previewBox dd {
+  margin: 0;
+  color: #f8fafc;
 }
 
 .status {
@@ -94,6 +151,11 @@
 .error {
   background: #450a0a;
   color: #fca5a5;
+}
+
+.errorList {
+  margin: 0;
+  padding-left: 18px;
 }
 
 .resultBox {

--- a/frontend/src/pages/PhaseSchedulingPage.test.jsx
+++ b/frontend/src/pages/PhaseSchedulingPage.test.jsx
@@ -2,101 +2,157 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import PhaseSchedulingPage from './PhaseSchedulingPage';
 import apiClient from '../utils/apiClient';
+import apiConfig from '../config/api';
 
 vi.mock('../utils/apiClient');
+
+const mockPhases = [
+  {
+    phaseId: 'phase-123',
+    submissionStart: '2026-04-25T09:00:00.000Z',
+    submissionEnd: '2026-05-02T09:00:00.000Z',
+  },
+  {
+    phaseId: 'phase-empty',
+    submissionStart: null,
+    submissionEnd: null,
+  },
+];
+
+const renderWithPhases = () => {
+  apiClient.get.mockResolvedValueOnce({ data: mockPhases });
+  render(<PhaseSchedulingPage />);
+};
 
 describe('PhaseSchedulingPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should set the minimum submissionEnd date based on submissionStart', () => {
-    render(<PhaseSchedulingPage />);
+  it('loads phases and removes issue-specific UI copy', async () => {
+    renderWithPhases();
+
+    expect(screen.queryByText(/Issue #78/i)).toBeNull();
+    expect(await screen.findByRole('option', { name: 'phase-123' })).toBeTruthy();
+    expect(apiClient.get).toHaveBeenCalledWith(apiConfig.endpoints.phases);
+  });
+
+  it('disables submit until a phase is selected', async () => {
+    renderWithPhases();
+
+    await screen.findByRole('option', { name: 'phase-123' });
+    const submitButton = screen.getByRole('button', { name: /Update Phase Schedule/i });
+    expect(submitButton.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText(/^Phase$/i), { target: { value: 'phase-123' } });
+
+    expect(submitButton.disabled).toBe(false);
+  });
+
+  it('loads and displays the selected phase schedule', async () => {
+    renderWithPhases();
+
+    fireEvent.change(await screen.findByLabelText(/^Phase$/i), { target: { value: 'phase-123' } });
+
+    expect(screen.getByText(/Current Schedule/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Submission Start/i).value).toBeTruthy();
+    expect(screen.getByLabelText(/Submission End/i).value).toBeTruthy();
+  });
+
+  it('sets the minimum submissionEnd date based on submissionStart', async () => {
+    renderWithPhases();
+
+    fireEvent.change(await screen.findByLabelText(/^Phase$/i), { target: { value: 'phase-123' } });
 
     const startInput = screen.getByLabelText(/Submission Start/i);
     const endInput = screen.getByLabelText(/Submission End/i);
 
     fireEvent.change(startInput, { target: { value: '2026-04-25T09:00' } });
 
-    expect(endInput.value).toBeTruthy();
     expect(endInput.min).toBe('2026-04-25T09:00');
   });
 
-  it('should display a validation error when submissionEnd equals submissionStart', async () => {
-    render(<PhaseSchedulingPage />);
+  it('displays inline validation errors when required dates are missing', async () => {
+    renderWithPhases();
 
-    const phaseIdInput = screen.getByLabelText(/Phase ID/i);
-    const startInput = screen.getByLabelText(/Submission Start/i);
-    const endInput = screen.getByLabelText(/Submission End/i);
-    const submitButton = screen.getByRole('button', { name: /Update Phase Schedule/i });
+    fireEvent.change(await screen.findByLabelText(/^Phase$/i), { target: { value: 'phase-empty' } });
+    fireEvent.click(screen.getByRole('button', { name: /Update Phase Schedule/i }));
 
-    fireEvent.change(phaseIdInput, { target: { value: 'phase-123' } });
-    fireEvent.change(startInput, { target: { value: '2026-04-25T09:00' } });
-    fireEvent.change(endInput, { target: { value: '2026-04-25T09:00' } });
+    await waitFor(() => {
+      expect(screen.getByText(/Submission start is required/i)).toBeTruthy();
+      expect(screen.getByText(/Submission end is required/i)).toBeTruthy();
+    });
+  });
 
-    fireEvent.click(submitButton);
+  it('displays a validation error when submissionEnd equals submissionStart', async () => {
+    renderWithPhases();
+
+    fireEvent.change(await screen.findByLabelText(/^Phase$/i), { target: { value: 'phase-123' } });
+    fireEvent.change(screen.getByLabelText(/Submission Start/i), { target: { value: '2026-04-25T09:00' } });
+    fireEvent.change(screen.getByLabelText(/Submission End/i), { target: { value: '2026-04-25T09:00' } });
+    fireEvent.click(screen.getByRole('button', { name: /Update Phase Schedule/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/Submission end date must be strictly after the submission start date/i)).toBeTruthy();
     });
   });
 
-  it('should show a success toast and result when the API call succeeds', async () => {
+  it('resets edited values to the selected phase schedule', async () => {
+    renderWithPhases();
+
+    fireEvent.change(await screen.findByLabelText(/^Phase$/i), { target: { value: 'phase-123' } });
+
+    const startInput = screen.getByLabelText(/Submission Start/i);
+    const originalStart = startInput.value;
+
+    fireEvent.change(startInput, { target: { value: '2026-04-26T10:00' } });
+    fireEvent.click(screen.getByRole('button', { name: /Reset/i }));
+
+    expect(startInput.value).toBe(originalStart);
+  });
+
+  it('shows a success message and refreshed result when the API call succeeds', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: mockPhases });
     apiClient.put.mockResolvedValueOnce({
       data: {
         phaseId: 'phase-123',
-        submissionStart: '2026-04-25T09:00:00.000Z',
-        submissionEnd: '2026-05-02T09:00:00.000Z',
+        submissionStart: '2026-04-26T09:00:00.000Z',
+        submissionEnd: '2026-05-03T09:00:00.000Z',
       },
     });
 
     render(<PhaseSchedulingPage />);
 
-    const phaseIdInput = screen.getByLabelText(/Phase ID/i);
-    const submitButton = screen.getByRole('button', { name: /Update Phase Schedule/i });
-
-    fireEvent.change(phaseIdInput, { target: { value: 'phase-123' } });
-    fireEvent.click(submitButton);
+    fireEvent.change(await screen.findByLabelText(/^Phase$/i), { target: { value: 'phase-123' } });
+    fireEvent.change(screen.getByLabelText(/Submission Start/i), { target: { value: '2026-04-26T09:00' } });
+    fireEvent.change(screen.getByLabelText(/Submission End/i), { target: { value: '2026-05-03T09:00' } });
+    fireEvent.click(screen.getByRole('button', { name: /Update Phase Schedule/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/Phase phase-123 schedule updated successfully/i)).toBeTruthy();
     });
 
     expect(screen.getByText(/Updated Phase/i)).toBeTruthy();
-    expect(apiClient.put).toHaveBeenCalled();
+    expect(apiClient.put).toHaveBeenCalledWith(apiConfig.endpoints.phaseSchedule('phase-123'), {
+      submissionStart: expect.stringMatching(/Z$/),
+      submissionEnd: expect.stringMatching(/Z$/),
+    });
   });
 
-  it('should render backend error messages when the schedule update fails', async () => {
+  it('renders backend array validation messages cleanly', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: mockPhases });
     apiClient.put.mockRejectedValueOnce({
-      response: { data: { message: 'Phase not found' } },
+      response: { data: { message: ['submissionStart must be a valid ISO date', 'submissionEnd must be a valid ISO date'] } },
     });
 
     render(<PhaseSchedulingPage />);
 
-    const phaseIdInput = screen.getByLabelText(/Phase ID/i);
-    const submitButton = screen.getByRole('button', { name: /Update Phase Schedule/i });
-
-    fireEvent.change(phaseIdInput, { target: { value: 'invalid-phase' } });
-    fireEvent.click(submitButton);
+    fireEvent.change(await screen.findByLabelText(/^Phase$/i), { target: { value: 'phase-123' } });
+    fireEvent.click(screen.getByRole('button', { name: /Update Phase Schedule/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Phase not found/i)).toBeTruthy();
-    });
-  });
-
-  it('should display an invalid date error when a malformed date is entered', async () => {
-    render(<PhaseSchedulingPage />);
-
-    const startInput = screen.getByLabelText(/Submission Start/i);
-    const endInput = screen.getByLabelText(/Submission End/i);
-    const submitButton = screen.getByRole('button', { name: /Update Phase Schedule/i });
-
-    fireEvent.change(startInput, { target: { value: 'invalid-date' } });
-    fireEvent.change(endInput, { target: { value: '2026-04-30T12:00' } });
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(screen.getByText(/Please enter valid submission start and end dates/i)).toBeTruthy();
+      expect(screen.getByText(/submissionStart must be a valid ISO date/i)).toBeTruthy();
+      expect(screen.getByText(/submissionEnd must be a valid ISO date/i)).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
1. PR Type
 Feature: Adds new functionality or API endpoint.
 Bug Fix: Resolves an identified issue or bug.
 Chore: Routine tasks, deleting unused files, or dependency updates.
 Refactor: Code restructuring without changing behavior.
 Documentation: Updates to docs/ or README.

2. Purpose & Description
Problem Statement:
The current Phase Scheduling page requires Coordinators to manually type a phaseId and still contains issue-specific UI copy. This makes the scheduling workflow error-prone because Coordinators cannot select phases from the UI or preview the current schedule before updating it.

Changes Made:

Added a Coordinator-only GET /phases endpoint to return phase scheduling data for the UI.
Added frontend API config support for the phase list endpoint.
Replaced the free-text phaseId input in PhaseSchedulingPage with a backend-driven phase dropdown.
Displayed the selected phase’s current submissionStart and submissionEnd values before editing.
Disabled submit until a phase is selected.
Added inline validation for missing dates, invalid dates, and end-before-start ranges.
Added a Reset button to restore the selected phase’s current schedule values.
Removed issue-number UI copy and replaced it with production-facing page text.
Rendered backend validation errors cleanly for both array and string message formats.
Updated the existing PhaseSchedulingPage test coverage to match the new scheduling workflow.

Related Issue: N/A

3. Testing & Verification
What Was Tested:

Frontend phase scheduling page loads phases from the backend endpoint.
Coordinator can select a phase from the dropdown.
Current schedule values are shown and loaded into the form.
Submit remains disabled until a phase is selected.
Reset restores the selected phase’s current schedule values.
Invalid/missing dates are blocked with readable inline errors.
Backend string/array validation messages render cleanly.
Existing frontend test suite still passes.

Verification Steps (How to test):

Run targeted Phase Scheduling frontend tests:
cd frontend
npm.cmd exec vitest run src/pages/PhaseSchedulingPage.test.jsx

Run the full frontend test suite:
cd frontend
npm.cmd exec vitest run

Manually verify /phases/schedule as a Coordinator:
Select a phase from the dropdown.
Confirm current schedule values are displayed.
Edit start/end dates.
Use Reset to restore current values.
Submit a valid range and confirm the success result.

Proof of Verification:

API/Backend:
GET /phases was added under PhasesController with Coordinator-only access.
Full backend suite was attempted, but existing unrelated failures in submissions, groups, and committees specs currently block a clean full backend run.

Frontend/UI:
Targeted Phase Scheduling test passed.
PhaseSchedulingPage.test.jsx: 9 passed.

Unit/E2E Tests:
Full frontend suite passed.
4 test files passed.
24 tests passed.

Chore/Refactor:
Not applicable.

4. Strict Checklist
 My PR targets the main branch.
 I have updated related API/System documentation if applicable.
 I have kept the changes strictly focused on the stated purpose.

5. Executive Summary
Summary: This PR replaces the manual Phase Scheduling form with a Coordinator-friendly phase picker backed by GET /phases. It shows current schedule values, adds reset and validation behavior, and removes issue-specific UI copy from the production page. The existing frontend tests were updated for the new workflow and the frontend suite passes.
