### PR TITLE
134 process 8 grade calculation 81 fetch verify story points

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/src/main.js",
     "seed:test-users": "ts-node scripts/seed-test-users.ts",
+    "seed:full": "ts-node scripts/seed-full.ts",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/backend/scripts/seed-full.ts
+++ b/backend/scripts/seed-full.ts
@@ -1,0 +1,381 @@
+/**
+ * Full seed script — creates a complete test environment covering every major feature:
+ *
+ *   Users        : 1 Admin, 2 Coordinators, 3 Professors (Advisors), 6 Students, 2 Team Leaders
+ *   Groups       : 2 active groups, each with a team leader + 2 students
+ *   Advisor link : Group-1 advisor assigned + approved AdvisorRequest
+ *   Committee    : 1 committee with jury + advisor members, assigned to both groups
+ *   Team         : 1 team linked to Group-1 (JIRA / GitHub keys set)
+ *   Phase        : 1 open submission phase
+ *   Submission   : 1 SOW + 1 RevisedProposal for Group-1
+ *   SprintConfig : 1 active SCRUM sprint for Group-1
+ *   StoryPoints  : 2 JIRA_GITHUB records (one per student in Group-1)
+ *
+ * Run:
+ *   npm run seed:full
+ *
+ * All passwords:  SecurePass123!
+ * All UUIDs are stable — re-running the script is idempotent.
+ */
+
+import 'dotenv/config';
+import { NestFactory } from '@nestjs/core';
+import { getModelToken } from '@nestjs/mongoose';
+import * as bcrypt from 'bcrypt';
+import { Model } from 'mongoose';
+import { AppModule } from '../src/app.module';
+
+import { Role } from '../src/auth/enums/role.enum';
+import { User, UserDocument } from '../src/users/data/user.schema';
+import {
+  Group,
+  GroupDocument,
+  GroupAssignmentStatus,
+  GroupStatus,
+} from '../src/groups/group.entity';
+import {
+  AdvisorRequest,
+  AdvisorRequestDocument,
+  AdvisorRequestStatus,
+} from '../src/advisors/schemas/advisor-request.schema';
+import {
+  Committee,
+  CommitteeDocument,
+} from '../src/committees/schemas/committee.schema';
+import { Team, TeamDocument } from '../src/teams/schemas/team.schema';
+import { Phase, PhaseDocument } from '../src/phases/phase.entity';
+import {
+  Submission,
+  SubmissionDocument,
+} from '../src/submissions/schemas/submission.schema';
+import {
+  SprintConfig,
+  SprintConfigDocument,
+} from '../src/story-points/schemas/sprint-config.schema';
+import {
+  StoryPointRecord,
+  StoryPointRecordDocument,
+  StoryPointSource,
+} from '../src/story-points/schemas/story-point-record.schema';
+
+// Use plain console so output is visible regardless of NestJS log level config
+const log = {
+  log:   (msg: string) => console.log(`[SeedFull] ${msg}`),
+  error: (msg: string) => console.error(`[SeedFull] ERROR ${msg}`),
+};
+
+// ─── Stable UUIDs ────────────────────────────────────────────────────────────
+const IDS = {
+  // users
+  admin:        'a0000000-0000-0000-0000-000000000001',
+  coord1:       'a0000000-0000-0000-0000-000000000002',
+  coord2:       'a0000000-0000-0000-0000-000000000003',
+  prof1:        'a0000000-0000-0000-0000-000000000004',
+  prof2:        'a0000000-0000-0000-0000-000000000005',
+  prof3:        'a0000000-0000-0000-0000-000000000006',
+  tl1:          'a0000000-0000-0000-0000-000000000007',
+  tl2:          'a0000000-0000-0000-0000-000000000008',
+  student1:     'a0000000-0000-0000-0000-000000000009',
+  student2:     'a0000000-0000-0000-0000-000000000010',
+  student3:     'a0000000-0000-0000-0000-000000000011',
+  student4:     'a0000000-0000-0000-0000-000000000012',
+  student5:     'a0000000-0000-0000-0000-000000000013',
+  student6:     'a0000000-0000-0000-0000-000000000014',
+  // groups
+  group1:       'b0000000-0000-0000-0000-000000000001',
+  group2:       'b0000000-0000-0000-0000-000000000002',
+  // committee
+  committee1:   'c0000000-0000-0000-0000-000000000001',
+  // phase
+  phase1:       'd0000000-0000-0000-0000-000000000001',
+  // sprint
+  sprint1:      'e0000000-0000-0000-0000-000000000001',
+};
+
+const PASSWORD = 'SecurePass123!';
+
+// ─── User definitions ────────────────────────────────────────────────────────
+const USERS = [
+  { id: IDS.admin,    email: 'admin@example.com',      role: Role.Admin,       name: 'Admin User' },
+  { id: IDS.coord1,   email: 'coordinator1@example.com', role: Role.Coordinator, name: 'Coordinator One' },
+  { id: IDS.coord2,   email: 'coordinator2@example.com', role: Role.Coordinator, name: 'Coordinator Two' },
+  { id: IDS.prof1,    email: 'professor1@example.com',  role: Role.Professor,   name: 'Professor One' },
+  { id: IDS.prof2,    email: 'professor2@example.com',  role: Role.Professor,   name: 'Professor Two' },
+  { id: IDS.prof3,    email: 'professor3@example.com',  role: Role.Professor,   name: 'Professor Three' },
+  { id: IDS.tl1,      email: 'teamleader1@example.com', role: Role.TeamLeader,  name: 'Team Leader One',   teamId: IDS.group1 },
+  { id: IDS.tl2,      email: 'teamleader2@example.com', role: Role.TeamLeader,  name: 'Team Leader Two',   teamId: IDS.group2 },
+  { id: IDS.student1, email: 'student1@example.com',    role: Role.Student,     name: 'Student One',       teamId: IDS.group1 },
+  { id: IDS.student2, email: 'student2@example.com',    role: Role.Student,     name: 'Student Two',       teamId: IDS.group1 },
+  { id: IDS.student3, email: 'student3@example.com',    role: Role.Student,     name: 'Student Three',     teamId: IDS.group1 },
+  { id: IDS.student4, email: 'student4@example.com',    role: Role.Student,     name: 'Student Four',      teamId: IDS.group2 },
+  { id: IDS.student5, email: 'student5@example.com',    role: Role.Student,     name: 'Student Five',      teamId: IDS.group2 },
+  { id: IDS.student6, email: 'student6@example.com',    role: Role.Student,     name: 'Student Six',       teamId: IDS.group2 },
+];
+
+async function main(): Promise<void> {
+  if (!process.env.MONGODB_URI) {
+    throw new Error('MONGODB_URI is not set. Make sure backend/.env is available.');
+  }
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+
+  try {
+    const userModel        = app.get<Model<UserDocument>>(getModelToken(User.name));
+    const groupModel       = app.get<Model<GroupDocument>>(getModelToken(Group.name));
+    const advisorReqModel  = app.get<Model<AdvisorRequestDocument>>(getModelToken(AdvisorRequest.name));
+    const committeeModel   = app.get<Model<CommitteeDocument>>(getModelToken(Committee.name));
+    const teamModel        = app.get<Model<TeamDocument>>(getModelToken(Team.name));
+    const phaseModel       = app.get<Model<PhaseDocument>>(getModelToken(Phase.name));
+    const submissionModel  = app.get<Model<SubmissionDocument>>(getModelToken(Submission.name));
+    const sprintModel      = app.get<Model<SprintConfigDocument>>(getModelToken(SprintConfig.name));
+    const spModel          = app.get<Model<StoryPointRecordDocument>>(getModelToken(StoryPointRecord.name));
+
+    // ── 1. Users ─────────────────────────────────────────────────────────────
+    log.log('Seeding users…');
+    const passwordHash = await bcrypt.hash(PASSWORD, 12);
+
+    for (const u of USERS) {
+      await userModel.updateOne(
+        { email: u.email },
+        {
+          $set: {
+            email: u.email,
+            passwordHash,
+            role: u.role,
+            ...(u.teamId ? { teamId: u.teamId } : {}),
+          },
+        },
+        { upsert: true },
+      );
+      log.log(`  ${u.role.padEnd(12)} ${u.email}`);
+    }
+
+    // Retrieve _id values to use as leaderUserId in groups
+    const tl1Doc = await userModel.findOne({ email: 'teamleader1@example.com' }).exec();
+    const tl2Doc = await userModel.findOne({ email: 'teamleader2@example.com' }).exec();
+
+    // ── 2. Groups ─────────────────────────────────────────────────────────────
+    log.log('Seeding groups…');
+
+    await groupModel.updateOne(
+      { groupId: IDS.group1 },
+      {
+        $set: {
+          groupId: IDS.group1,
+          groupName: 'Alpha Team',
+          leaderUserId: tl1Doc!._id.toString(),
+          advisorUserId: IDS.prof1,
+          assignedAdvisorId: IDS.prof1,
+          status: GroupStatus.ACTIVE,
+          assignmentStatus: GroupAssignmentStatus.ASSIGNED,
+        },
+      },
+      { upsert: true },
+    );
+    log.log('  Group-1: Alpha Team (advisor assigned)');
+
+    await groupModel.updateOne(
+      { groupId: IDS.group2 },
+      {
+        $set: {
+          groupId: IDS.group2,
+          groupName: 'Beta Team',
+          leaderUserId: tl2Doc!._id.toString(),
+          advisorUserId: undefined,
+          assignedAdvisorId: null,
+          status: GroupStatus.ACTIVE,
+          assignmentStatus: GroupAssignmentStatus.UNASSIGNED,
+        },
+      },
+      { upsert: true },
+    );
+    log.log('  Group-2: Beta Team (no advisor yet)');
+
+    // ── 3. Advisor request (approved) for Group-1 ────────────────────────────
+    log.log('Seeding advisor request…');
+    await advisorReqModel.updateOne(
+      { groupId: IDS.group1, status: AdvisorRequestStatus.APPROVED },
+      {
+        $set: {
+          requestId: 'f0000000-0000-0000-0000-000000000001',
+          groupId: IDS.group1,
+          submittedBy: tl1Doc!._id.toString(),
+          requestedAdvisorId: IDS.prof1,
+          status: AdvisorRequestStatus.APPROVED,
+        },
+      },
+      { upsert: true },
+    );
+    log.log('  AdvisorRequest: Group-1 ← Professor One (APPROVED)');
+
+    // ── 4. Committee ──────────────────────────────────────────────────────────
+    log.log('Seeding committee…');
+    await committeeModel.updateOne(
+      { id: IDS.committee1 },
+      {
+        $set: {
+          id: IDS.committee1,
+          name: 'Spring 2026 Review Committee',
+          jury: [
+            { userId: IDS.coord1, name: 'Coordinator One' },
+            { userId: IDS.coord2, name: 'Coordinator Two' },
+          ],
+          advisors: [
+            { userId: IDS.prof1, name: 'Professor One' },
+            { userId: IDS.prof2, name: 'Professor Two' },
+          ],
+          groups: [
+            { groupId: IDS.group1, assignedAt: new Date(), assignedByUserId: IDS.coord1 },
+            { groupId: IDS.group2, assignedAt: new Date(), assignedByUserId: IDS.coord1 },
+          ],
+        },
+      },
+      { upsert: true },
+    );
+    log.log('  Committee: Spring 2026 Review Committee (2 groups, 2 jury, 2 advisors)');
+
+    // ── 5. Team (JIRA + GitHub) for Group-1 ──────────────────────────────────
+    log.log('Seeding team…');
+    await teamModel.updateOne(
+      { leaderId: tl1Doc!._id.toString() },
+      {
+        $set: {
+          name: 'Alpha Team',
+          leaderId: tl1Doc!._id.toString(),
+          jiraProjectKey: 'ALPHA',
+          githubRepositoryId: 'org/alpha-repo',
+        },
+      },
+      { upsert: true },
+    );
+    log.log('  Team: Alpha Team (jiraProjectKey=ALPHA, githubRepositoryId=org/alpha-repo)');
+
+    // ── 6. Phase ──────────────────────────────────────────────────────────────
+    log.log('Seeding phase…');
+    const now = new Date();
+    const oneMonthAgo = new Date(now); oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+    const oneMonthAhead = new Date(now); oneMonthAhead.setMonth(oneMonthAhead.getMonth() + 1);
+
+    await phaseModel.updateOne(
+      { phaseId: IDS.phase1 },
+      {
+        $set: {
+          phaseId: IDS.phase1,
+          submissionStart: oneMonthAgo,
+          submissionEnd: oneMonthAhead,
+          requiredFields: ['title', 'documents'],
+        },
+      },
+      { upsert: true },
+    );
+    log.log('  Phase: open submission window (±1 month from today)');
+
+    // ── 7. Submissions for Group-1 ────────────────────────────────────────────
+    log.log('Seeding submissions…');
+    await submissionModel.updateOne(
+      { groupId: IDS.group1, type: 'SOW' },
+      {
+        $set: {
+          title: 'Alpha Team — Statement of Work',
+          groupId: IDS.group1,
+          type: 'SOW',
+          phaseId: IDS.phase1,
+          status: 'Approved',
+          submittedAt: new Date(),
+          documents: [
+            { originalName: 'sow.pdf', mimeType: 'application/pdf', uploadedAt: new Date() },
+          ],
+        },
+      },
+      { upsert: true },
+    );
+    await submissionModel.updateOne(
+      { groupId: IDS.group1, type: 'RevisedProposal' },
+      {
+        $set: {
+          title: 'Alpha Team — Revised Proposal',
+          groupId: IDS.group1,
+          type: 'RevisedProposal',
+          phaseId: IDS.phase1,
+          status: 'Approved',
+          submittedAt: new Date(),
+          documents: [
+            { originalName: 'revised-proposal.pdf', mimeType: 'application/pdf', uploadedAt: new Date() },
+          ],
+        },
+      },
+      { upsert: true },
+    );
+    log.log('  Submissions: SOW + RevisedProposal for Group-1 (both Approved)');
+
+    // ── 8. Sprint config for Group-1 (story points) ───────────────────────────
+    log.log('Seeding sprint config…');
+    await sprintModel.updateOne(
+      { sprintId: IDS.sprint1, groupId: IDS.group1 },
+      {
+        $set: {
+          sprintId: IDS.sprint1,
+          groupId: IDS.group1,
+          targetStoryPoints: 20,
+          startDate: oneMonthAgo,
+          endDate: oneMonthAhead,
+          phase: 'SCRUM',
+        },
+      },
+      { upsert: true },
+    );
+    log.log('  SprintConfig: Sprint-1 for Group-1 (target=20 pts, active window)');
+
+    // ── 9. Story point records for Group-1 sprint ────────────────────────────
+    log.log('Seeding story point records…');
+
+    const spRecords = [
+      { studentId: IDS.student1, completedPoints: 8 },
+      { studentId: IDS.student2, completedPoints: 12 },
+    ];
+
+    for (const rec of spRecords) {
+      await spModel.updateOne(
+        { studentId: rec.studentId, sprintId: IDS.sprint1 },
+        {
+          $set: {
+            studentId: rec.studentId,
+            groupId: IDS.group1,
+            sprintId: IDS.sprint1,
+            completedPoints: rec.completedPoints,
+            targetPoints: 20,
+            source: StoryPointSource.JIRA_GITHUB,
+          },
+        },
+        { upsert: true },
+      );
+    }
+    log.log('  StoryPoints: student1=8 pts, student2=12 pts (source=JIRA_GITHUB)');
+
+    // ── Summary ───────────────────────────────────────────────────────────────
+    log.log('');
+    log.log('═══════════════════════════════════════════════════');
+    log.log('  SEED COMPLETE — test credentials');
+    log.log('  Password for all accounts: SecurePass123!');
+    log.log('───────────────────────────────────────────────────');
+    log.log('  ROLE          EMAIL');
+    for (const u of USERS) {
+      log.log(`  ${u.role.padEnd(12)}  ${u.email}`);
+    }
+    log.log('───────────────────────────────────────────────────');
+    log.log(`  Group-1 UUID : ${IDS.group1}`);
+    log.log(`  Group-2 UUID : ${IDS.group2}`);
+    log.log(`  Sprint UUID  : ${IDS.sprint1}`);
+    log.log(`  Phase UUID   : ${IDS.phase1}`);
+    log.log('═══════════════════════════════════════════════════');
+  } finally {
+    await app.close();
+  }
+}
+
+void main().catch((err: unknown) => {
+  log.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { InvitesModule } from './invites/invites.module';
+import { StoryPointsModule } from './story-points/story-points.module';
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -30,6 +31,7 @@ import { CommitteesModule } from './committees/committees.module';
     SubmissionsModule,
     CommitteesModule,
     InvitesModule,
+    StoryPointsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/story-points/dto/fetch-story-points.dto.ts
+++ b/backend/src/story-points/dto/fetch-story-points.dto.ts
@@ -1,0 +1,13 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsUUID } from 'class-validator';
+
+export class FetchStoryPointsDto {
+  @ApiPropertyOptional({
+    description: 'Subset of student UUIDs to fetch; defaults to all group members',
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  studentIds?: string[];
+}

--- a/backend/src/story-points/dto/override-story-points.dto.ts
+++ b/backend/src/story-points/dto/override-story-points.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsUUID, Min } from 'class-validator';
+
+export class OverrideStoryPointsDto {
+  @ApiProperty({ description: 'UUID of the student to override' })
+  @IsUUID('4')
+  studentId!: string;
+
+  @ApiProperty({ description: 'Override completed story points (must be >= 0)', minimum: 0 })
+  @IsInt()
+  @Min(0)
+  completedPoints!: number;
+}

--- a/backend/src/story-points/dto/story-point-summary.dto.ts
+++ b/backend/src/story-points/dto/story-point-summary.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { StoryPointSource } from '../schemas/story-point-record.schema';
+
+export class StudentStoryPointRecordDto {
+  @ApiProperty() studentId!: string;
+  @ApiProperty() completedPoints!: number;
+  @ApiProperty() targetPoints!: number;
+  @ApiProperty({ enum: StoryPointSource }) source!: StoryPointSource;
+  @ApiProperty() updatedAt!: Date;
+}
+
+export class StoryPointSummaryDto {
+  @ApiProperty() groupId!: string;
+  @ApiProperty() sprintId!: string;
+  @ApiProperty({ type: [StudentStoryPointRecordDto] })
+  records!: StudentStoryPointRecordDto[];
+}

--- a/backend/src/story-points/jira-github.service.ts
+++ b/backend/src/story-points/jira-github.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface ExternalStoryPoints {
+  studentId: string;
+  completedPoints: number;
+}
+
+@Injectable()
+export class JiraGithubService {
+  private readonly logger = new Logger(JiraGithubService.name);
+
+  /**
+   * Fetches completed story points for the given students from JIRA/GitHub.
+   * Throws an error (to be mapped to 502) when the external API is unreachable.
+   */
+  async fetchStoryPoints(
+    groupId: string,
+    sprintId: string,
+    studentIds: string[],
+  ): Promise<ExternalStoryPoints[]> {
+    const apiUrl = process.env.JIRA_GITHUB_API_URL;
+
+    if (!apiUrl) {
+      this.logger.warn(
+        `JIRA_GITHUB_API_URL not configured — returning zero points for group=${groupId} sprint=${sprintId}`,
+      );
+      return studentIds.map((id) => ({ studentId: id, completedPoints: 0 }));
+    }
+
+    try {
+      const url = `${apiUrl}/groups/${groupId}/sprints/${sprintId}/story-points`;
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${process.env.JIRA_GITHUB_API_TOKEN ?? ''}` },
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!response.ok) {
+        throw new Error(`External API responded with status ${response.status}`);
+      }
+
+      const data = (await response.json()) as ExternalStoryPoints[];
+      return data.filter((r) => studentIds.includes(r.studentId));
+    } catch (err) {
+      this.logger.error(
+        `JIRA/GitHub API unreachable for group=${groupId} sprint=${sprintId}: ${(err as Error).message}`,
+      );
+      throw err;
+    }
+  }
+}

--- a/backend/src/story-points/schemas/sprint-config.schema.ts
+++ b/backend/src/story-points/schemas/sprint-config.schema.ts
@@ -1,0 +1,30 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+import { randomUUID } from 'crypto';
+
+export type SprintConfigDocument = HydratedDocument<SprintConfig>;
+
+@Schema({ timestamps: true })
+export class SprintConfig {
+  @Prop({ type: String, default: () => randomUUID(), unique: true })
+  sprintId!: string;
+
+  @Prop({ required: true, index: true })
+  groupId!: string;
+
+  @Prop({ required: true, min: 0 })
+  targetStoryPoints!: number;
+
+  @Prop({ required: true })
+  startDate!: Date;
+
+  @Prop({ required: true })
+  endDate!: Date;
+
+  @Prop({ type: String, default: 'SCRUM' })
+  phase!: string;
+}
+
+export const SprintConfigSchema = SchemaFactory.createForClass(SprintConfig);
+
+SprintConfigSchema.index({ groupId: 1, sprintId: 1 }, { unique: true });

--- a/backend/src/story-points/schemas/story-point-record.schema.ts
+++ b/backend/src/story-points/schemas/story-point-record.schema.ts
@@ -1,0 +1,40 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+import { randomUUID } from 'crypto';
+
+export type StoryPointRecordDocument = HydratedDocument<StoryPointRecord>;
+
+export enum StoryPointSource {
+  JIRA_GITHUB = 'JIRA_GITHUB',
+  COORDINATOR_OVERRIDE = 'COORDINATOR_OVERRIDE',
+  MANUAL = 'MANUAL',
+}
+
+@Schema({ timestamps: true })
+export class StoryPointRecord {
+  @Prop({ type: String, default: () => randomUUID() })
+  recordId!: string;
+
+  @Prop({ required: true, index: true })
+  studentId!: string;
+
+  @Prop({ required: true, index: true })
+  groupId!: string;
+
+  @Prop({ required: true, index: true })
+  sprintId!: string;
+
+  @Prop({ required: true, min: 0 })
+  completedPoints!: number;
+
+  @Prop({ required: true, min: 0 })
+  targetPoints!: number;
+
+  @Prop({ required: true, enum: Object.values(StoryPointSource) })
+  source!: StoryPointSource;
+}
+
+export const StoryPointRecordSchema =
+  SchemaFactory.createForClass(StoryPointRecord);
+
+StoryPointRecordSchema.index({ studentId: 1, sprintId: 1 }, { unique: true });

--- a/backend/src/story-points/story-points.controller.spec.ts
+++ b/backend/src/story-points/story-points.controller.spec.ts
@@ -1,0 +1,214 @@
+import {
+  BadGatewayException,
+  BadRequestException,
+  ForbiddenException,
+  UnauthorizedException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Role } from '../auth/enums/role.enum';
+import { StoryPointSource } from './schemas/story-point-record.schema';
+import { StoryPointsController } from './story-points.controller';
+import { StoryPointsService } from './story-points.service';
+import { StoryPointSummaryDto, StudentStoryPointRecordDto } from './dto/story-point-summary.dto';
+
+const GROUP_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const SPRINT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const STUDENT_A = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const NOW = new Date('2026-04-30T12:00:00Z');
+
+const mockSummary: StoryPointSummaryDto = {
+  groupId: GROUP_ID,
+  sprintId: SPRINT_ID,
+  records: [
+    { studentId: STUDENT_A, completedPoints: 5, targetPoints: 10, source: StoryPointSource.JIRA_GITHUB, updatedAt: NOW },
+  ],
+};
+
+const mockRecord: StudentStoryPointRecordDto = {
+  studentId: STUDENT_A,
+  completedPoints: 15,
+  targetPoints: 10,
+  source: StoryPointSource.COORDINATOR_OVERRIDE,
+  updatedAt: NOW,
+};
+
+describe('StoryPointsController', () => {
+  let controller: StoryPointsController;
+
+  const mockService = {
+    fetchAndVerify: jest.fn(),
+    getRecords: jest.fn(),
+    override: jest.fn(),
+  };
+
+  const coordinatorReq: any = { user: { userId: 'coord-1', role: Role.Coordinator } };
+  const professorReq: any = { user: { userId: 'prof-1', role: Role.Professor } };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StoryPointsController],
+      providers: [{ provide: StoryPointsService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<StoryPointsController>(StoryPointsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────
+  // POST fetchAndVerify
+  // ──────────────────────────────────────────────
+  describe('fetchAndVerify (POST)', () => {
+    it('200: returns StoryPointSummary shape', async () => {
+      mockService.fetchAndVerify.mockResolvedValue(mockSummary);
+
+      const result = await controller.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, coordinatorReq);
+
+      expect(result).toEqual(mockSummary);
+      expect(mockService.fetchAndVerify).toHaveBeenCalledWith(GROUP_ID, SPRINT_ID, {}, 'coord-1');
+    });
+
+    it('200: ADVISOR (Professor) can trigger fetch', async () => {
+      mockService.fetchAndVerify.mockResolvedValue(mockSummary);
+
+      const result = await controller.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, professorReq);
+      expect(result).toEqual(mockSummary);
+    });
+
+    it('502: propagates BadGatewayException from service', async () => {
+      mockService.fetchAndVerify.mockRejectedValue(new BadGatewayException('JIRA/GitHub API unreachable'));
+
+      await expect(
+        controller.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, coordinatorReq),
+      ).rejects.toThrow(BadGatewayException);
+    });
+
+    it('422: propagates UnprocessableEntityException from service', async () => {
+      mockService.fetchAndVerify.mockRejectedValue(
+        new UnprocessableEntityException('Sprint config missing'),
+      );
+
+      await expect(
+        controller.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, coordinatorReq),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // GET getStoryPoints
+  // ──────────────────────────────────────────────
+  describe('getStoryPoints (GET)', () => {
+    it('200: returns StoryPointSummary', async () => {
+      mockService.getRecords.mockResolvedValue(mockSummary);
+
+      const result = await controller.getStoryPoints(GROUP_ID, SPRINT_ID);
+
+      expect(result).toEqual(mockSummary);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // PATCH overrideStoryPoints
+  // ──────────────────────────────────────────────
+  describe('overrideStoryPoints (PATCH)', () => {
+    it('200: returns single StudentStoryPointRecord with COORDINATOR_OVERRIDE source', async () => {
+      mockService.override.mockResolvedValue(mockRecord);
+
+      const result = await controller.overrideStoryPoints(
+        GROUP_ID,
+        SPRINT_ID,
+        { studentId: STUDENT_A, completedPoints: 15 },
+        coordinatorReq,
+      );
+
+      expect(result).toEqual(mockRecord);
+      expect(result.source).toBe(StoryPointSource.COORDINATOR_OVERRIDE);
+    });
+
+    it('403: ForbiddenException when ADVISOR attempts PATCH override', async () => {
+      mockService.override.mockRejectedValue(new ForbiddenException('Insufficient permissions'));
+
+      await expect(
+        controller.overrideStoryPoints(GROUP_ID, SPRINT_ID, { studentId: STUDENT_A, completedPoints: 5 }, professorReq),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('propagates 422 when sprint config missing', async () => {
+      mockService.override.mockRejectedValue(new UnprocessableEntityException('Sprint config missing'));
+
+      await expect(
+        controller.overrideStoryPoints(GROUP_ID, SPRINT_ID, { studentId: STUDENT_A, completedPoints: 5 }, coordinatorReq),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // 401: Simulated missing JWT (guard behaviour)
+  // ──────────────────────────────────────────────
+  describe('401 simulation (guard)', () => {
+    it('fetchAndVerify rejects when service throws UnauthorizedException', async () => {
+      mockService.fetchAndVerify.mockRejectedValue(new UnauthorizedException());
+      await expect(
+        controller.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, coordinatorReq),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('getStoryPoints rejects when service throws UnauthorizedException', async () => {
+      mockService.getRecords.mockRejectedValue(new UnauthorizedException());
+      await expect(controller.getStoryPoints(GROUP_ID, SPRINT_ID)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('overrideStoryPoints rejects when service throws UnauthorizedException', async () => {
+      mockService.override.mockRejectedValue(new UnauthorizedException());
+      await expect(
+        controller.overrideStoryPoints(GROUP_ID, SPRINT_ID, { studentId: STUDENT_A, completedPoints: 5 }, coordinatorReq),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // 400: negative completedPoints — DTO validation (service-level check)
+  // ──────────────────────────────────────────────
+  describe('400 validation', () => {
+    it('propagates BadRequestException for negative completedPoints', async () => {
+      mockService.override.mockRejectedValue(new BadRequestException('completedPoints must not be less than 0'));
+
+      await expect(
+        controller.overrideStoryPoints(
+          GROUP_ID,
+          SPRINT_ID,
+          { studentId: STUDENT_A, completedPoints: -1 },
+          coordinatorReq,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // RBAC metadata checks
+  // ──────────────────────────────────────────────
+  describe('RBAC metadata', () => {
+    it('fetchAndVerify allows Coordinator and Professor', () => {
+      const roles = Reflect.getMetadata('roles', controller.fetchAndVerify);
+      expect(roles).toEqual(expect.arrayContaining([Role.Coordinator, Role.Professor]));
+    });
+
+    it('getStoryPoints allows Coordinator and Professor', () => {
+      const roles = Reflect.getMetadata('roles', controller.getStoryPoints);
+      expect(roles).toEqual(expect.arrayContaining([Role.Coordinator, Role.Professor]));
+    });
+
+    it('overrideStoryPoints allows only Coordinator', () => {
+      const roles = Reflect.getMetadata('roles', controller.overrideStoryPoints);
+      expect(roles).toEqual([Role.Coordinator]);
+      expect(roles).not.toContain(Role.Professor);
+    });
+  });
+});

--- a/backend/src/story-points/story-points.controller.ts
+++ b/backend/src/story-points/story-points.controller.ts
@@ -1,0 +1,113 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBadGatewayResponse,
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
+import { Request as ExpressRequest } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../auth/enums/role.enum';
+import { StoryPointsService } from './story-points.service';
+import { FetchStoryPointsDto } from './dto/fetch-story-points.dto';
+import { OverrideStoryPointsDto } from './dto/override-story-points.dto';
+import {
+  StoryPointSummaryDto,
+  StudentStoryPointRecordDto,
+} from './dto/story-point-summary.dto';
+
+interface RequestWithUser extends ExpressRequest {
+  user: { userId?: string; sub?: string; role: string };
+}
+
+@ApiTags('Story Points')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('groups/:groupId/sprints/:sprintId/story-points')
+export class StoryPointsController {
+  constructor(private readonly storyPointsService: StoryPointsService) {}
+
+  @Post()
+  @Roles(Role.Coordinator, Role.Professor)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    operationId: 'fetchAndVerifyStoryPoints',
+    summary: 'Fetch and verify story points from JIRA/GitHub per student per sprint',
+  })
+  @ApiOkResponse({ description: 'Story points fetched and verified', type: StoryPointSummaryDto })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiForbiddenResponse({ description: 'Requires COORDINATOR or ADVISOR role' })
+  @ApiNotFoundResponse({ description: 'Group, sprint config, or student not found' })
+  @ApiUnprocessableEntityResponse({ description: 'Sprint config missing or no active sprint window' })
+  @ApiBadGatewayResponse({ description: 'JIRA/GitHub API unreachable' })
+  async fetchAndVerify(
+    @Param('groupId', new ParseUUIDPipe()) groupId: string,
+    @Param('sprintId', new ParseUUIDPipe()) sprintId: string,
+    @Body() dto: FetchStoryPointsDto,
+    @Request() req: RequestWithUser,
+  ): Promise<StoryPointSummaryDto> {
+    const requestedBy = req.user.userId ?? req.user.sub ?? 'unknown';
+    return this.storyPointsService.fetchAndVerify(groupId, sprintId, dto, requestedBy);
+  }
+
+  @Get()
+  @Roles(Role.Coordinator, Role.Professor)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    operationId: 'getStoryPoints',
+    summary: 'Get story point records for a group sprint',
+  })
+  @ApiOkResponse({ description: 'Story point records returned', type: StoryPointSummaryDto })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiForbiddenResponse({ description: 'Requires COORDINATOR or ADVISOR role' })
+  @ApiUnprocessableEntityResponse({ description: 'Sprint config not found' })
+  async getStoryPoints(
+    @Param('groupId', new ParseUUIDPipe()) groupId: string,
+    @Param('sprintId', new ParseUUIDPipe()) sprintId: string,
+  ): Promise<StoryPointSummaryDto> {
+    return this.storyPointsService.getRecords(groupId, sprintId);
+  }
+
+  @Patch('override')
+  @Roles(Role.Coordinator)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    operationId: 'overrideStoryPoints',
+    summary: 'Override story points for a student (COORDINATOR only)',
+  })
+  @ApiOkResponse({
+    description: 'Story point record updated with COORDINATOR_OVERRIDE',
+    type: StudentStoryPointRecordDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiForbiddenResponse({ description: 'Requires COORDINATOR role' })
+  @ApiNotFoundResponse({ description: 'Sprint config or student record not found' })
+  async overrideStoryPoints(
+    @Param('groupId', new ParseUUIDPipe()) groupId: string,
+    @Param('sprintId', new ParseUUIDPipe()) sprintId: string,
+    @Body() dto: OverrideStoryPointsDto,
+    @Request() req: RequestWithUser,
+  ): Promise<StudentStoryPointRecordDto> {
+    const requestedBy = req.user.userId ?? req.user.sub ?? 'unknown';
+    return this.storyPointsService.override(groupId, sprintId, dto, requestedBy);
+  }
+}

--- a/backend/src/story-points/story-points.module.ts
+++ b/backend/src/story-points/story-points.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { StoryPointsController } from './story-points.controller';
+import { StoryPointsService } from './story-points.service';
+import { JiraGithubService } from './jira-github.service';
+import {
+  StoryPointRecord,
+  StoryPointRecordSchema,
+} from './schemas/story-point-record.schema';
+import { SprintConfig, SprintConfigSchema } from './schemas/sprint-config.schema';
+import { User, UserSchema } from '../users/data/user.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: StoryPointRecord.name, schema: StoryPointRecordSchema },
+      { name: SprintConfig.name, schema: SprintConfigSchema },
+      { name: User.name, schema: UserSchema },
+    ]),
+  ],
+  controllers: [StoryPointsController],
+  providers: [StoryPointsService, JiraGithubService],
+  exports: [StoryPointsService],
+})
+export class StoryPointsModule {}

--- a/backend/src/story-points/story-points.service.spec.ts
+++ b/backend/src/story-points/story-points.service.spec.ts
@@ -1,0 +1,258 @@
+import {
+  BadGatewayException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SprintConfig } from './schemas/sprint-config.schema';
+import {
+  StoryPointRecord,
+  StoryPointSource,
+} from './schemas/story-point-record.schema';
+import { StoryPointsService } from './story-points.service';
+import { JiraGithubService } from './jira-github.service';
+import { User } from '../users/data/user.schema';
+
+const NOW = new Date('2026-04-30T12:00:00Z');
+const SPRINT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const GROUP_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const STUDENT_A = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const STUDENT_B = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+const activeSprintConfig = {
+  sprintId: SPRINT_ID,
+  groupId: GROUP_ID,
+  targetStoryPoints: 10,
+  startDate: new Date('2026-04-01'),
+  endDate: new Date('2026-05-31'),
+  phase: 'SCRUM',
+};
+
+function makeRecordModel() {
+  const model: any = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+  };
+  model.findOne.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+  model.find.mockReturnValue({ exec: jest.fn().mockResolvedValue([]) });
+  model.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+  return model;
+}
+
+function makeSprintModel(config = activeSprintConfig) {
+  return { findOne: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(config) }) };
+}
+
+function makeUserModel(ids: string[] = [STUDENT_A, STUDENT_B]) {
+  const docs = ids.map((id) => ({ _id: { toString: () => id } }));
+  return { find: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(docs) }) };
+}
+
+describe('StoryPointsService', () => {
+  let service: StoryPointsService;
+  let recordModel: ReturnType<typeof makeRecordModel>;
+  let sprintModel: ReturnType<typeof makeSprintModel>;
+  let userModel: ReturnType<typeof makeUserModel>;
+  let jiraService: { fetchStoryPoints: jest.Mock };
+
+  beforeEach(async () => {
+    jest.useFakeTimers().setSystemTime(NOW);
+
+    recordModel = makeRecordModel();
+    sprintModel = makeSprintModel();
+    userModel = makeUserModel();
+    jiraService = { fetchStoryPoints: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StoryPointsService,
+        { provide: getModelToken(StoryPointRecord.name), useValue: recordModel },
+        { provide: getModelToken(SprintConfig.name), useValue: sprintModel },
+        { provide: getModelToken(User.name), useValue: userModel },
+        { provide: JiraGithubService, useValue: jiraService },
+      ],
+    }).compile();
+
+    service = module.get<StoryPointsService>(StoryPointsService);
+  });
+
+  afterEach(() => jest.useRealTimers());
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────
+  // fetchAndVerify
+  // ──────────────────────────────────────────────
+  describe('fetchAndVerify', () => {
+    it('happy path: fetches JIRA_GITHUB records for all group members', async () => {
+      jiraService.fetchStoryPoints.mockResolvedValue([
+        { studentId: STUDENT_A, completedPoints: 5 },
+        { studentId: STUDENT_B, completedPoints: 8 },
+      ]);
+
+      const updatedA = { studentId: STUDENT_A, completedPoints: 5, targetPoints: 10, source: StoryPointSource.JIRA_GITHUB, updatedAt: NOW };
+      const updatedB = { studentId: STUDENT_B, completedPoints: 8, targetPoints: 10, source: StoryPointSource.JIRA_GITHUB, updatedAt: NOW };
+
+      recordModel.findOneAndUpdate
+        .mockReturnValueOnce({ exec: jest.fn().mockResolvedValue(updatedA) })
+        .mockReturnValueOnce({ exec: jest.fn().mockResolvedValue(updatedB) });
+
+      recordModel.find.mockReturnValue({
+        exec: jest.fn().mockResolvedValue([updatedA, updatedB]),
+      });
+
+      const result = await service.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, 'coord-1');
+
+      expect(jiraService.fetchStoryPoints).toHaveBeenCalledWith(GROUP_ID, SPRINT_ID, [STUDENT_A, STUDENT_B]);
+      expect(result.groupId).toBe(GROUP_ID);
+      expect(result.sprintId).toBe(SPRINT_ID);
+      expect(result.records).toHaveLength(2);
+    });
+
+    it('COORDINATOR_OVERRIDE is NOT overwritten by a subsequent JIRA_GITHUB fetch', async () => {
+      jiraService.fetchStoryPoints.mockResolvedValue([
+        { studentId: STUDENT_A, completedPoints: 3 },
+      ]);
+
+      const overrideRecord = {
+        studentId: STUDENT_A,
+        completedPoints: 99,
+        source: StoryPointSource.COORDINATOR_OVERRIDE,
+      };
+
+      recordModel.findOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(overrideRecord),
+      });
+
+      recordModel.find.mockReturnValue({
+        exec: jest.fn().mockResolvedValue([overrideRecord]),
+      });
+
+      userModel.find.mockReturnValue({
+        exec: jest.fn().mockResolvedValue([{ _id: { toString: () => STUDENT_A } }]),
+      });
+
+      await service.fetchAndVerify(GROUP_ID, SPRINT_ID, { studentIds: [STUDENT_A] }, 'coord-1');
+
+      expect(recordModel.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('throws 502 BadGatewayException when JIRA/GitHub API is unreachable', async () => {
+      jiraService.fetchStoryPoints.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(
+        service.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, 'coord-1'),
+      ).rejects.toThrow(BadGatewayException);
+    });
+
+    it('throws 422 UnprocessableEntityException when sprint config missing in D2', async () => {
+      sprintModel.findOne.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+
+      await expect(
+        service.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, 'coord-1'),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('throws 422 when sprint window is not active', async () => {
+      const expiredConfig = {
+        ...activeSprintConfig,
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-02-01'),
+      };
+      sprintModel.findOne.mockReturnValue({ exec: jest.fn().mockResolvedValue(expiredConfig) });
+
+      await expect(
+        service.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, 'coord-1'),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('throws 404 NotFoundException when group has no members', async () => {
+      jiraService.fetchStoryPoints.mockResolvedValue([]);
+      userModel.find.mockReturnValue({ exec: jest.fn().mockResolvedValue([]) });
+
+      await expect(
+        service.fetchAndVerify(GROUP_ID, SPRINT_ID, {}, 'coord-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('filters to given studentIds subset', async () => {
+      jiraService.fetchStoryPoints.mockResolvedValue([
+        { studentId: STUDENT_A, completedPoints: 6 },
+      ]);
+
+      const updatedA = { studentId: STUDENT_A, completedPoints: 6, targetPoints: 10, source: StoryPointSource.JIRA_GITHUB, updatedAt: NOW };
+      recordModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updatedA) });
+      recordModel.find.mockReturnValue({ exec: jest.fn().mockResolvedValue([updatedA]) });
+
+      await service.fetchAndVerify(GROUP_ID, SPRINT_ID, { studentIds: [STUDENT_A] }, 'coord-1');
+
+      expect(jiraService.fetchStoryPoints).toHaveBeenCalledWith(GROUP_ID, SPRINT_ID, [STUDENT_A]);
+      expect(userModel.find).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // override
+  // ──────────────────────────────────────────────
+  describe('override', () => {
+    it('happy path: upserts record with COORDINATOR_OVERRIDE source', async () => {
+      const saved = {
+        studentId: STUDENT_A,
+        completedPoints: 15,
+        targetPoints: 10,
+        source: StoryPointSource.COORDINATOR_OVERRIDE,
+        updatedAt: NOW,
+      };
+      recordModel.findOne.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+      recordModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(saved) });
+
+      const result = await service.override(
+        GROUP_ID,
+        SPRINT_ID,
+        { studentId: STUDENT_A, completedPoints: 15 },
+        'coord-1',
+      );
+
+      expect(result.source).toBe(StoryPointSource.COORDINATOR_OVERRIDE);
+      expect(result.completedPoints).toBe(15);
+    });
+
+    it('throws 422 when sprint config is missing', async () => {
+      sprintModel.findOne.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+
+      await expect(
+        service.override(GROUP_ID, SPRINT_ID, { studentId: STUDENT_A, completedPoints: 5 }, 'coord-1'),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // getRecords
+  // ──────────────────────────────────────────────
+  describe('getRecords', () => {
+    it('returns summary without modifying state', async () => {
+      const records = [
+        { studentId: STUDENT_A, completedPoints: 5, targetPoints: 10, source: StoryPointSource.JIRA_GITHUB, updatedAt: NOW },
+      ];
+      recordModel.find.mockReturnValue({ exec: jest.fn().mockResolvedValue(records) });
+
+      const result = await service.getRecords(GROUP_ID, SPRINT_ID);
+
+      expect(result.groupId).toBe(GROUP_ID);
+      expect(result.records).toHaveLength(1);
+      expect(recordModel.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('throws 422 when sprint config is missing', async () => {
+      sprintModel.findOne.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+
+      await expect(service.getRecords(GROUP_ID, SPRINT_ID)).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+    });
+  });
+});

--- a/backend/src/story-points/story-points.service.ts
+++ b/backend/src/story-points/story-points.service.ts
@@ -1,0 +1,213 @@
+import {
+  BadGatewayException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  SprintConfig,
+  SprintConfigDocument,
+} from './schemas/sprint-config.schema';
+import {
+  StoryPointRecord,
+  StoryPointRecordDocument,
+  StoryPointSource,
+} from './schemas/story-point-record.schema';
+import { User, UserDocument } from '../users/data/user.schema';
+import { FetchStoryPointsDto } from './dto/fetch-story-points.dto';
+import { OverrideStoryPointsDto } from './dto/override-story-points.dto';
+import {
+  StoryPointSummaryDto,
+  StudentStoryPointRecordDto,
+} from './dto/story-point-summary.dto';
+import { JiraGithubService } from './jira-github.service';
+
+@Injectable()
+export class StoryPointsService {
+  private readonly logger = new Logger(StoryPointsService.name);
+
+  constructor(
+    @InjectModel(StoryPointRecord.name)
+    private readonly recordModel: Model<StoryPointRecordDocument>,
+    @InjectModel(SprintConfig.name)
+    private readonly sprintConfigModel: Model<SprintConfigDocument>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
+    private readonly jiraGithubService: JiraGithubService,
+  ) {}
+
+  async fetchAndVerify(
+    groupId: string,
+    sprintId: string,
+    dto: FetchStoryPointsDto,
+    requestedBy: string,
+  ): Promise<StoryPointSummaryDto> {
+    const sprintConfig = await this.requireSprintConfig(groupId, sprintId);
+    this.assertActiveSprintWindow(sprintConfig);
+
+    const studentIds = dto.studentIds?.length
+      ? dto.studentIds
+      : await this.resolveGroupMemberIds(groupId);
+
+    let externalResults: { studentId: string; completedPoints: number }[];
+    try {
+      externalResults = await this.jiraGithubService.fetchStoryPoints(
+        groupId,
+        sprintId,
+        studentIds,
+      );
+    } catch {
+      throw new BadGatewayException('JIRA/GitHub API unreachable');
+    }
+
+    const pointsMap = new Map(
+      externalResults.map((r) => [r.studentId, r.completedPoints]),
+    );
+
+    for (const studentId of studentIds) {
+      const existing = await this.recordModel
+        .findOne({ studentId, sprintId })
+        .exec();
+
+      if (existing?.source === StoryPointSource.COORDINATOR_OVERRIDE) {
+        this.logger.log(
+          `Skipping fetch for studentId=${studentId} sprintId=${sprintId} — COORDINATOR_OVERRIDE protected`,
+        );
+        continue;
+      }
+
+      const completedPoints = pointsMap.get(studentId) ?? 0;
+
+      await this.recordModel
+        .findOneAndUpdate(
+          { studentId, sprintId },
+          {
+            studentId,
+            groupId,
+            sprintId,
+            completedPoints,
+            targetPoints: sprintConfig.targetStoryPoints,
+            source: StoryPointSource.JIRA_GITHUB,
+          },
+          { upsert: true, new: true },
+        )
+        .exec();
+    }
+
+    this.logger.log(
+      `fetchAndVerify groupId=${groupId} sprintId=${sprintId} requestedBy=${requestedBy} source=JIRA_GITHUB`,
+    );
+
+    return this.buildSummary(groupId, sprintId);
+  }
+
+  async override(
+    groupId: string,
+    sprintId: string,
+    dto: OverrideStoryPointsDto,
+    requestedBy: string,
+  ): Promise<StudentStoryPointRecordDto> {
+    const sprintConfig = await this.requireSprintConfig(groupId, sprintId);
+
+    const existing = await this.recordModel
+      .findOne({ studentId: dto.studentId, sprintId })
+      .exec();
+
+    const oldSource = existing?.source ?? 'NONE';
+
+    const updated = await this.recordModel
+      .findOneAndUpdate(
+        { studentId: dto.studentId, sprintId },
+        {
+          studentId: dto.studentId,
+          groupId,
+          sprintId,
+          completedPoints: dto.completedPoints,
+          targetPoints: sprintConfig.targetStoryPoints,
+          source: StoryPointSource.COORDINATOR_OVERRIDE,
+        },
+        { upsert: true, new: true },
+      )
+      .exec();
+
+    if (!updated) {
+      throw new NotFoundException('Failed to upsert story point override');
+    }
+
+    this.logger.log(
+      `override studentId=${dto.studentId} sprintId=${sprintId} oldSource=${oldSource} newSource=COORDINATOR_OVERRIDE triggeredBy=${requestedBy}`,
+    );
+
+    return this.toRecordDto(updated);
+  }
+
+  async getRecords(
+    groupId: string,
+    sprintId: string,
+  ): Promise<StoryPointSummaryDto> {
+    await this.requireSprintConfig(groupId, sprintId);
+    return this.buildSummary(groupId, sprintId);
+  }
+
+  private async requireSprintConfig(
+    groupId: string,
+    sprintId: string,
+  ): Promise<SprintConfig> {
+    const config = await this.sprintConfigModel
+      .findOne({ groupId, sprintId })
+      .exec();
+
+    if (!config) {
+      throw new UnprocessableEntityException(
+        `Sprint config not found for groupId=${groupId} sprintId=${sprintId}`,
+      );
+    }
+    return config;
+  }
+
+  private assertActiveSprintWindow(config: SprintConfig): void {
+    const now = new Date();
+    if (now < config.startDate || now > config.endDate) {
+      throw new UnprocessableEntityException(
+        `No active sprint window for sprintId=${config.sprintId}`,
+      );
+    }
+  }
+
+  private async resolveGroupMemberIds(groupId: string): Promise<string[]> {
+    const members = await this.userModel
+      .find({ teamId: groupId }, { _id: 1 })
+      .exec();
+
+    if (!members.length) {
+      throw new NotFoundException(`No members found for groupId=${groupId}`);
+    }
+
+    return members.map((m) => (m._id as unknown as { toString(): string }).toString());
+  }
+
+  private async buildSummary(
+    groupId: string,
+    sprintId: string,
+  ): Promise<StoryPointSummaryDto> {
+    const records = await this.recordModel.find({ groupId, sprintId }).exec();
+    return {
+      groupId,
+      sprintId,
+      records: records.map((r) => this.toRecordDto(r)),
+    };
+  }
+
+  private toRecordDto(record: StoryPointRecordDocument): StudentStoryPointRecordDto {
+    return {
+      studentId: record.studentId,
+      completedPoints: record.completedPoints,
+      targetPoints: record.targetPoints,
+      source: record.source,
+      updatedAt: (record as any).updatedAt as Date,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Adds the Process 8.1 story-points backend flow: coordinators and professors can fetch verified sprint story points from the external JIRA/GitHub source, coordinators can override a student's story points, and the backend now seeds sprint config and story-point records for local testing.

Closes #134 

---

## Type of Change
- [x] Feature (new endpoint or business logic)
- [x] Configuration / infrastructure
- [ ] Refactor (no behavior change)
- [ ] Background job / scheduled task
- [ ] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change

**Backend:**
- Controller(s): `StoryPointsController`
- Use case(s) / service(s): `StoryPointsService`, `JiraGithubService`
- Repository / DB layer: `StoryPointRecord`, `SprintConfig`, and the user lookup used to resolve group members
- Schema / migration: new story-point record and sprint config schemas with unique indexes
- OpenAPI spec file(s): `docs/api/api-specs/process8.yaml` already covers these endpoints; it was not modified in this branch

**Frontend:** (if applicable)
- N/A

**Infrastructure / Config:** (if applicable)
- `AppModule` now registers `StoryPointsModule`
- `backend/package.json` adds the `seed:full` script
- `backend/scripts/seed-full.ts` seeds a sprint config and verified story-point records for Group-1

---

## API Contract Alignment

| Field | Value |
|---|---|
| Endpoint | `POST /groups/{groupId}/sprints/{sprintId}/story-points; GET /groups/{groupId}/sprints/{sprintId}/story-points; PATCH /groups/{groupId}/sprints/{sprintId}/story-points/override` |
| OperationId | `fetchAndVerifyStoryPoints; getStoryPoints; overrideStoryPoints` |
| OpenAPI file | `process8.yaml` |
| Spec updated in this PR | No |

- [ ] Response shape matches OpenAPI schema exactly
- [ ] All documented status codes are reachable via implementation
- [ ] No fields added to response that are not in the spec
- [ ] groupId / actorId extracted from JWT — NOT from request body (if applicable)

---

## Clean Architecture Checklist

**Infrastructure / API layer:**
- [ ] Auth guard behavior matches status code matrix in issue
- [ ] Controller returns contract-compliant response shape
- [ ] Input validation rules enforced (required fields, UUID format, enum values)

**Application / Use Case layer:**
- [x] Use case orchestrates all validations before any DB write
- [x] Sensitive fields never exposed in response DTOs
- [x] Error mapping is deterministic — same input always produces same error code

**Domain / Repository layer:**
- [x] Repository queries enforce correct domain filters (role scoping, ownership)
- [x] Concurrency / uniqueness constraints protected at DB level, not only application level
- [x] All DB failures caught and mapped to generic 500 — no raw DB errors reach the client

---

## Test Evidence

**Unit tests:**
- [ ] Happy path covered
- [ ] All business-rule failure cases covered (see Section 11 of issue)
- [ ] Repository failure mapping tested

**Controller tests:**
- [ ] 401 unauthorized (missing/invalid JWT)
- [ ] 403 forbidden (wrong role or ownership mismatch)
- [ ] Success response shape and status code
- [ ] Validation error response (400)

**Integration / E2E tests:**
- [ ] Happy flow end-to-end
- [ ] Conflict / locked / not-found flow end-to-end
- [ ] Contract parity with OpenAPI verified

**Test file locations:**
- Unit: `backend/src/story-points/story-points.service.spec.ts`
- Controller: `backend/src/story-points/story-points.controller.spec.ts`
- E2E: none added in this branch

**Test run output:**
- Not run in this session

---

## Status Code Matrix Verification

| Code | Scenario | Tested |
|---|---|---|
| 2xx | Happy path | ☐ |
| 400 | Validation failure | ☐ |
| 401 | Missing/invalid JWT | ☐ |
| 403 | Role or ownership mismatch | ☐ |
| 404 | Resource not found | ☐ |
| 409 | Conflict | ☐ |
| 4xx | Other (specify) | ☐ |
| 500 | DB/internal failure | ☐ |

---

## Observability Checklist
- [ ] Key business event is logged with correlationId / requestId
- [ ] No secrets, tokens, hashes, or sensitive personal data in logs
- [ ] 500 responses include actionable internal context in server logs
- [ ] Audit log entry written (if this is a POST, PATCH, or DELETE operation — requires Issue 47 to be merged first)

---

## Migration / Breaking Change Assessment
- [x] No database migration required
- [ ] Migration included and tested with rollback plan
- [x] No breaking change to API contract
- [ ] Breaking change — existing consumers notified: [describe]
- [x] Backward compatibility note: N/A

---

## Out of Scope Confirmation
The following are explicitly out of scope for this PR and were not implemented:
- Frontend UI for story-point management
- Real JIRA/GitHub integration UI or settings screens
- Database migration scripts
- Additional grade-calculation logic beyond the story-points feature itself

---

## Dependencies
- Blocked by: none
- Must be merged before: none
- Requires Issue 47 (Audit logging) to be merged first: No

---

## Reviewer Notes
- This branch adds the story-points backend module, supporting DTOs/schemas, tests, and local seed data.
- The controller currently exposes POST and GET on `/groups/:groupId/sprints/:sprintId/story-points` plus a PATCH override route under `/override`; if strict OpenAPI parity is required, double-check the spec path for the override flow before merge.

---

## Definition of Done Sign-off
- [ ] Implementation merged with passing tests
- [ ] OpenAPI spec updated and aligned with implementation
- [ ] QA scenarios executed and evidenced above
- [ ] PR description includes test evidence and status-matrix coverage
- [ ] No TODO comments left in production code
- [ ] No console.log or debug statements left in code
