### PR TITLE
Add Deliverables module, API, service and tests

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -17,6 +17,7 @@ import { SubmissionsModule } from './submissions/submissions.module';
 import { CommitteesModule } from './committees/committees.module';
 import { GradesModule } from './grades/grades.module';
 import { SprintEvaluationsModule } from './sprint-evaluations/sprint-evaluations.module';
+import { DeliverablesModule } from './deliverables/deliverables.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { SprintEvaluationsModule } from './sprint-evaluations/sprint-evaluations
     StoryPointsModule,
     GradesModule,
     SprintEvaluationsModule,
+    DeliverablesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/deliverables/deliverables.controller.spec.ts
+++ b/backend/src/deliverables/deliverables.controller.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeliverablesController } from './deliverables.controller';
+import { DeliverablesService } from './deliverables.service';
+import { Role } from '../auth/enums/role.enum';
+
+describe('DeliverablesController', () => {
+  let controller: DeliverablesController;
+  let service: DeliverablesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DeliverablesController],
+      providers: [
+        {
+          provide: DeliverablesService,
+          useValue: {
+            listDeliverables: jest.fn(),
+            createDeliverable: jest.fn(),
+            updateDeliverable: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(DeliverablesController);
+    service = module.get(DeliverablesService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('uses the expected roles metadata for listing', () => {
+    const roles = Reflect.getMetadata('roles', controller.listDeliverables);
+    expect(roles).toEqual(
+      expect.arrayContaining([Role.Coordinator, Role.Professor, Role.Admin]),
+    );
+  });
+
+  it('uses coordinator-only access for creation', () => {
+    const roles = Reflect.getMetadata('roles', controller.createDeliverable);
+    expect(roles).toEqual([Role.Coordinator]);
+  });
+
+  it('uses coordinator-only access for updates', () => {
+    const roles = Reflect.getMetadata('roles', controller.updateDeliverable);
+    expect(roles).toEqual([Role.Coordinator]);
+  });
+
+  it('passes actorId and correlationId to create service', async () => {
+    jest.spyOn(service, 'createDeliverable').mockResolvedValue({
+      deliverableId: '11111111-1111-4111-8111-111111111111',
+      name: 'SoW',
+      categoryWeight: 0.5,
+      subWeight: 0.35,
+      deliverablePercentage: 17.5,
+      createdAt: new Date('2026-05-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-05-01T10:00:00.000Z'),
+    });
+
+    const req = {
+      user: { userId: 'coord-1', role: Role.Coordinator },
+      headers: { 'x-correlation-id': 'corr-1' },
+    } as any;
+
+    await controller.createDeliverable(
+      {
+        name: 'SoW',
+        categoryWeight: 0.5,
+        subWeight: 0.35,
+        deliverablePercentage: 17.5,
+      },
+      req,
+    );
+
+    expect(service.createDeliverable).toHaveBeenCalledWith(
+      {
+        name: 'SoW',
+        categoryWeight: 0.5,
+        subWeight: 0.35,
+        deliverablePercentage: 17.5,
+      },
+      'coord-1',
+      'corr-1',
+    );
+  });
+
+  it('passes correlationId to list service', async () => {
+    jest.spyOn(service, 'listDeliverables').mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+    });
+
+    await controller.listDeliverables(
+      { page: 1, limit: 20 },
+      { headers: { 'x-correlation-id': 'corr-2' } } as any,
+    );
+
+    expect(service.listDeliverables).toHaveBeenCalledWith(
+      { page: 1, limit: 20 },
+      'corr-2',
+    );
+  });
+});

--- a/backend/src/deliverables/deliverables.controller.ts
+++ b/backend/src/deliverables/deliverables.controller.ts
@@ -1,0 +1,147 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
+  ApiCreatedResponse,
+} from '@nestjs/swagger';
+import type { Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../auth/enums/role.enum';
+import { CreateDeliverableDto } from './dto/create-deliverable.dto';
+import {
+  DeliverableResponseDto,
+  PaginatedDeliverablesDto,
+} from './dto/deliverable-response.dto';
+import { ListDeliverablesQueryDto } from './dto/list-deliverables-query.dto';
+import { UpdateDeliverableDto } from './dto/update-deliverable.dto';
+import { DeliverablesService } from './deliverables.service';
+
+interface RequestWithUser extends Request {
+  user?: {
+    userId?: string;
+    sub?: string;
+    _id?: string;
+    role?: string;
+  };
+}
+
+@ApiTags('Deliverables')
+@ApiBearerAuth('access-token')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('deliverables')
+export class DeliverablesController {
+  constructor(private readonly deliverablesService: DeliverablesService) {}
+
+  private getCorrelationId(req: Request): string | undefined {
+    const correlationId = req.headers['x-correlation-id'];
+    return typeof correlationId === 'string' ? correlationId : undefined;
+  }
+
+  private getActorId(req: RequestWithUser): string {
+    return req.user?.userId ?? req.user?.sub ?? req.user?._id ?? 'SYSTEM';
+  }
+
+  @ApiOperation({
+    operationId: 'listDeliverables',
+    summary: 'List deliverables with pagination',
+  })
+  @ApiOkResponse({ type: PaginatedDeliverablesDto })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiInternalServerErrorResponse({
+    description: 'Unexpected internal failure',
+  })
+  @Roles(Role.Coordinator, Role.Professor, Role.Admin)
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async listDeliverables(
+    @Query() query: ListDeliverablesQueryDto,
+    @Req() req: Request,
+  ): Promise<PaginatedDeliverablesDto> {
+    return this.deliverablesService.listDeliverables(
+      query,
+      this.getCorrelationId(req),
+    );
+  }
+
+  @ApiOperation({
+    operationId: 'createDeliverable',
+    summary: 'Create a deliverable',
+  })
+  @ApiCreatedResponse({ type: DeliverableResponseDto })
+  @ApiConflictResponse({ description: 'Deliverable name already exists' })
+  @ApiUnprocessableEntityResponse({
+    description: 'Deliverable percentage total would exceed 100',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiInternalServerErrorResponse({
+    description: 'Unexpected internal failure',
+  })
+  @Roles(Role.Coordinator)
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createDeliverable(
+    @Body() body: CreateDeliverableDto,
+    @Req() req: RequestWithUser,
+  ): Promise<DeliverableResponseDto> {
+    return this.deliverablesService.createDeliverable(
+      body,
+      this.getActorId(req),
+      this.getCorrelationId(req),
+    );
+  }
+
+  @ApiOperation({
+    operationId: 'updateDeliverableWeights',
+    summary: 'Update deliverable weights',
+  })
+  @ApiOkResponse({ type: DeliverableResponseDto })
+  @ApiNotFoundResponse({ description: 'Deliverable not found' })
+  @ApiUnprocessableEntityResponse({
+    description: 'Deliverable percentage total would exceed 100',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiInternalServerErrorResponse({
+    description: 'Unexpected internal failure',
+  })
+  @Roles(Role.Coordinator)
+  @Patch(':deliverableId')
+  @HttpCode(HttpStatus.OK)
+  async updateDeliverable(
+    @Param('deliverableId', new ParseUUIDPipe()) deliverableId: string,
+    @Body() body: UpdateDeliverableDto,
+    @Req() req: RequestWithUser,
+  ): Promise<DeliverableResponseDto> {
+    return this.deliverablesService.updateDeliverable(
+      deliverableId,
+      body,
+      this.getActorId(req),
+      this.getCorrelationId(req),
+    );
+  }
+}

--- a/backend/src/deliverables/deliverables.module.ts
+++ b/backend/src/deliverables/deliverables.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { DeliverablesController } from './deliverables.controller';
+import { DeliverablesService } from './deliverables.service';
+import { Deliverable, DeliverableSchema } from './schemas/deliverable.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Deliverable.name, schema: DeliverableSchema },
+    ]),
+  ],
+  controllers: [DeliverablesController],
+  providers: [DeliverablesService],
+  exports: [DeliverablesService, MongooseModule],
+})
+export class DeliverablesModule {}

--- a/backend/src/deliverables/deliverables.service.spec.ts
+++ b/backend/src/deliverables/deliverables.service.spec.ts
@@ -1,0 +1,267 @@
+import {
+  ConflictException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { getConnectionToken, getModelToken } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeliverablesService } from './deliverables.service';
+import { Deliverable } from './schemas/deliverable.schema';
+
+describe('DeliverablesService', () => {
+  let service: DeliverablesService;
+
+  const session = {
+    startTransaction: jest.fn(),
+    commitTransaction: jest.fn(),
+    abortTransaction: jest.fn(),
+    endSession: jest.fn(),
+    inTransaction: jest.fn().mockReturnValue(true),
+  };
+
+  const mockConnection = {
+    startSession: jest.fn().mockResolvedValue(session),
+  };
+
+  const mockDeliverableModel = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    countDocuments: jest.fn(),
+    create: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeliverablesService,
+        {
+          provide: getModelToken(Deliverable.name),
+          useValue: mockDeliverableModel,
+        },
+        {
+          provide: getConnectionToken(),
+          useValue: mockConnection,
+        },
+      ],
+    }).compile();
+
+    service = module.get(DeliverablesService);
+  });
+
+  it('lists deliverables with pagination', async () => {
+    const createdAt = new Date('2026-05-01T10:00:00.000Z');
+    const updatedAt = new Date('2026-05-02T10:00:00.000Z');
+
+    mockDeliverableModel.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            lean: jest.fn().mockReturnValue({
+              exec: jest.fn().mockResolvedValue([
+                {
+                  deliverableId: '11111111-1111-4111-8111-111111111111',
+                  name: 'SoW',
+                  categoryWeight: 0.5,
+                  subWeight: 0.35,
+                  deliverablePercentage: 17.5,
+                  createdAt,
+                  updatedAt,
+                },
+              ]),
+            }),
+          }),
+        }),
+      }),
+    });
+    mockDeliverableModel.countDocuments.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(1),
+    });
+
+    const result = await service.listDeliverables({ page: 1, limit: 20 });
+
+    expect(result.total).toBe(1);
+    expect(result.data[0].name).toBe('SoW');
+  });
+
+  it('creates a deliverable', async () => {
+    mockDeliverableModel.findOne.mockReturnValue({
+      session: jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue(null),
+        }),
+      }),
+    });
+    mockDeliverableModel.find.mockReturnValue({
+      session: jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const createdAt = new Date('2026-05-03T10:00:00.000Z');
+    const updatedAt = new Date('2026-05-03T10:00:00.000Z');
+    mockDeliverableModel.create.mockResolvedValue([
+      {
+        deliverableId: '22222222-2222-4222-8222-222222222222',
+        name: 'SoW',
+        categoryWeight: 0.5,
+        subWeight: 0.35,
+        deliverablePercentage: 17.5,
+        toObject: () => ({
+          deliverableId: '22222222-2222-4222-8222-222222222222',
+          name: 'SoW',
+          categoryWeight: 0.5,
+          subWeight: 0.35,
+          deliverablePercentage: 17.5,
+          createdAt,
+          updatedAt,
+        }),
+      },
+    ]);
+
+    const result = await service.createDeliverable(
+      {
+        name: 'SoW',
+        categoryWeight: 0.5,
+        subWeight: 0.35,
+        deliverablePercentage: 17.5,
+      },
+      'coord-1',
+    );
+
+    expect(result.deliverableId).toBe('22222222-2222-4222-8222-222222222222');
+    expect(session.commitTransaction).toHaveBeenCalled();
+  });
+
+  it('rejects duplicate names on create', async () => {
+    mockDeliverableModel.findOne.mockReturnValue({
+      session: jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue({
+            deliverableId: 'existing-id',
+            name: 'SoW',
+          }),
+        }),
+      }),
+    });
+
+    await expect(
+      service.createDeliverable(
+        {
+          name: 'SoW',
+          categoryWeight: 0.5,
+          subWeight: 0.35,
+          deliverablePercentage: 17.5,
+        },
+        'coord-1',
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('rejects percentage total above 100 on create', async () => {
+    mockDeliverableModel.findOne.mockReturnValue({
+      session: jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue(null),
+        }),
+      }),
+    });
+    mockDeliverableModel.find.mockReturnValue({
+      session: jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue([
+            { deliverablePercentage: 90 },
+          ]),
+        }),
+      }),
+    });
+
+    await expect(
+      service.createDeliverable(
+        {
+          name: 'SoW',
+          categoryWeight: 0.5,
+          subWeight: 0.35,
+          deliverablePercentage: 17.5,
+        },
+        'coord-1',
+      ),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+  });
+
+  it('updates a deliverable', async () => {
+    const existing = {
+      deliverableId: '33333333-3333-4333-8333-333333333333',
+      name: 'SoW',
+      categoryWeight: 0.5,
+      subWeight: 0.35,
+      deliverablePercentage: 17.5,
+      createdAt: new Date('2026-05-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-05-02T10:00:00.000Z'),
+      save: jest.fn().mockResolvedValue(undefined),
+      toObject: function () {
+        return this;
+      },
+    };
+
+    mockDeliverableModel.findOne.mockReturnValueOnce({
+      session: jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue(existing),
+      }),
+    });
+    mockDeliverableModel.find.mockReturnValue({
+      session: jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue([
+            { deliverablePercentage: 20 },
+          ]),
+        }),
+      }),
+    });
+
+    const result = await service.updateDeliverable(
+      existing.deliverableId,
+      { deliverablePercentage: 25 },
+      'coord-1',
+    );
+
+    expect(result.deliverablePercentage).toBe(25);
+    expect(existing.save).toHaveBeenCalled();
+  });
+
+  it('throws not found for missing deliverable on update', async () => {
+    mockDeliverableModel.findOne.mockReturnValue({
+      session: jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      }),
+    });
+
+    await expect(
+      service.updateDeliverable(
+        '44444444-4444-4444-8444-444444444444',
+        { deliverablePercentage: 10 },
+        'coord-1',
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('maps unexpected errors to 500', async () => {
+    mockConnection.startSession.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      service.createDeliverable(
+        {
+          name: 'SoW',
+          categoryWeight: 0.5,
+          subWeight: 0.35,
+          deliverablePercentage: 17.5,
+        },
+        'coord-1',
+      ),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+});

--- a/backend/src/deliverables/deliverables.service.ts
+++ b/backend/src/deliverables/deliverables.service.ts
@@ -1,0 +1,303 @@
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { InjectConnection, InjectModel } from '@nestjs/mongoose';
+import { ClientSession, Connection, Model } from 'mongoose';
+import { CreateDeliverableDto } from './dto/create-deliverable.dto';
+import { ListDeliverablesQueryDto } from './dto/list-deliverables-query.dto';
+import {
+  DeliverableResponseDto,
+  PaginatedDeliverablesDto,
+} from './dto/deliverable-response.dto';
+import { UpdateDeliverableDto } from './dto/update-deliverable.dto';
+import {
+  Deliverable,
+  DeliverableDocument,
+} from './schemas/deliverable.schema';
+
+@Injectable()
+export class DeliverablesService {
+  private readonly logger = new Logger(DeliverablesService.name);
+
+  constructor(
+    @InjectModel(Deliverable.name)
+    private readonly deliverableModel: Model<DeliverableDocument>,
+    @InjectConnection()
+    private readonly connection: Connection,
+  ) {}
+
+  async listDeliverables(
+    query: ListDeliverablesQueryDto,
+    correlationId?: string,
+  ): Promise<PaginatedDeliverablesDto> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    try {
+      const [data, total] = await Promise.all([
+        this.deliverableModel
+          .find()
+          .sort({ createdAt: 1, deliverableId: 1 })
+          .skip(skip)
+          .limit(limit)
+          .lean()
+          .exec(),
+        this.deliverableModel.countDocuments().exec(),
+      ]);
+
+      this.logger.log(
+        JSON.stringify({
+          event: 'deliverable.listed',
+          page,
+          limit,
+          resultCount: data.length,
+          correlationId: correlationId ?? null,
+        }),
+      );
+
+      return {
+        data: data.map((deliverable) => this.toResponseDto(deliverable)),
+        total,
+        page,
+        limit,
+      };
+    } catch (error) {
+      this.logger.error(
+        JSON.stringify({
+          event: 'deliverable.list_failed',
+          correlationId: correlationId ?? null,
+          error: (error as Error).message,
+        }),
+      );
+      throw new InternalServerErrorException(
+        'Failed to retrieve deliverables due to an unexpected error.',
+      );
+    }
+  }
+
+  async createDeliverable(
+    dto: CreateDeliverableDto,
+    actorId: string,
+    correlationId?: string,
+  ): Promise<DeliverableResponseDto> {
+    let session: ClientSession | null = null;
+
+    try {
+      session = await this.connection.startSession();
+      session.startTransaction();
+
+      await this.ensureUniqueName(dto.name, undefined, session);
+      await this.ensurePercentageBudget(
+        dto.deliverablePercentage,
+        undefined,
+        session,
+      );
+
+      const created = await this.deliverableModel.create(
+        [
+          {
+            name: dto.name.trim(),
+            categoryWeight: dto.categoryWeight,
+            subWeight: dto.subWeight,
+            deliverablePercentage: dto.deliverablePercentage,
+          },
+        ],
+        { session },
+      );
+
+      await session.commitTransaction();
+
+      const deliverable = created[0];
+
+      this.logger.log(
+        JSON.stringify({
+          event: 'deliverable.created',
+          deliverableId: deliverable.deliverableId,
+          actorId,
+          correlationId: correlationId ?? null,
+        }),
+      );
+
+      return this.toResponseDto(deliverable.toObject());
+    } catch (error) {
+      if (session?.inTransaction()) {
+        await session.abortTransaction();
+      }
+      throw this.toWriteException(error, correlationId);
+    } finally {
+      await session?.endSession();
+    }
+  }
+
+  async updateDeliverable(
+    deliverableId: string,
+    dto: UpdateDeliverableDto,
+    actorId: string,
+    correlationId?: string,
+  ): Promise<DeliverableResponseDto> {
+    let session: ClientSession | null = null;
+
+    try {
+      session = await this.connection.startSession();
+      session.startTransaction();
+
+      const existing = await this.deliverableModel
+        .findOne({ deliverableId })
+        .session(session)
+        .exec();
+
+      if (!existing) {
+        throw new NotFoundException(
+          `Deliverable with ID '${deliverableId}' not found.`,
+        );
+      }
+
+      const updatedPercentage =
+        dto.deliverablePercentage ?? existing.deliverablePercentage;
+
+      await this.ensurePercentageBudget(
+        updatedPercentage,
+        deliverableId,
+        session,
+      );
+
+      if (dto.categoryWeight !== undefined) {
+        existing.categoryWeight = dto.categoryWeight;
+      }
+
+      if (dto.subWeight !== undefined) {
+        existing.subWeight = dto.subWeight;
+      }
+
+      if (dto.deliverablePercentage !== undefined) {
+        existing.deliverablePercentage = dto.deliverablePercentage;
+      }
+
+      await existing.save({ session });
+      await session.commitTransaction();
+
+      this.logger.log(
+        JSON.stringify({
+          event: 'deliverable.updated',
+          deliverableId,
+          actorId,
+          correlationId: correlationId ?? null,
+        }),
+      );
+
+      return this.toResponseDto(existing.toObject());
+    } catch (error) {
+      if (session?.inTransaction()) {
+        await session.abortTransaction();
+      }
+      throw this.toWriteException(error, correlationId);
+    } finally {
+      await session?.endSession();
+    }
+  }
+
+  private async ensureUniqueName(
+    name: string,
+    excludedDeliverableId: string | undefined,
+    session: ClientSession,
+  ): Promise<void> {
+    const existing = await this.deliverableModel
+      .findOne({ name: name.trim() })
+      .session(session)
+      .lean()
+      .exec();
+
+    if (
+      existing &&
+      (!excludedDeliverableId || existing.deliverableId !== excludedDeliverableId)
+    ) {
+      throw new ConflictException(
+        `Deliverable with name '${name.trim()}' already exists.`,
+      );
+    }
+  }
+
+  private async ensurePercentageBudget(
+    nextPercentage: number,
+    excludedDeliverableId: string | undefined,
+    session: ClientSession,
+  ): Promise<void> {
+    const deliverables = await this.deliverableModel
+      .find(
+        excludedDeliverableId
+          ? { deliverableId: { $ne: excludedDeliverableId } }
+          : {},
+        { deliverablePercentage: 1, _id: 0 },
+      )
+      .session(session)
+      .lean()
+      .exec();
+
+    const total =
+      deliverables.reduce(
+        (sum, deliverable) => sum + deliverable.deliverablePercentage,
+        0,
+      ) + nextPercentage;
+
+    if (total > 100) {
+      throw new UnprocessableEntityException(
+        'Deliverable percentage total cannot exceed 100.',
+      );
+    }
+  }
+
+  private toWriteException(
+    error: unknown,
+    correlationId?: string,
+  ): Error {
+    if (
+      error instanceof ConflictException ||
+      error instanceof NotFoundException ||
+      error instanceof UnprocessableEntityException
+    ) {
+      return error;
+    }
+
+    const isDuplicateKey =
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: number }).code === 11000;
+
+    this.logger.error(
+      JSON.stringify({
+        event: 'deliverable.write_failed',
+        correlationId: correlationId ?? null,
+        error: (error as Error).message,
+      }),
+    );
+
+    if (isDuplicateKey) {
+      return new ConflictException('Deliverable name must be unique.');
+    }
+
+    return new InternalServerErrorException(
+      'Failed to persist deliverable due to an unexpected error.',
+    );
+  }
+
+  private toResponseDto(deliverable: Deliverable): DeliverableResponseDto {
+    return {
+      deliverableId: deliverable.deliverableId,
+      name: deliverable.name,
+      categoryWeight: deliverable.categoryWeight,
+      subWeight: deliverable.subWeight,
+      deliverablePercentage: deliverable.deliverablePercentage,
+      createdAt: (deliverable as Deliverable & { createdAt: Date }).createdAt,
+      updatedAt:
+        ((deliverable as Deliverable & { updatedAt?: Date | null }).updatedAt ??
+          null),
+    };
+  }
+}

--- a/backend/src/deliverables/dto/create-deliverable.dto.ts
+++ b/backend/src/deliverables/dto/create-deliverable.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class CreateDeliverableDto {
+  @ApiProperty({
+    description: 'Unique deliverable name',
+    example: 'Statement of Work',
+  })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({
+    description: 'Top-level category weight in the final grade formula',
+    example: 0.5,
+    minimum: 0,
+    maximum: 1,
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  categoryWeight!: number;
+
+  @ApiProperty({
+    description: 'Deliverable weight within its category',
+    example: 0.35,
+    minimum: 0,
+    maximum: 1,
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  subWeight!: number;
+
+  @ApiProperty({
+    description: 'Overall contribution percentage of the deliverable',
+    example: 17.5,
+    minimum: 0,
+    maximum: 100,
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  deliverablePercentage!: number;
+}

--- a/backend/src/deliverables/dto/deliverable-response.dto.ts
+++ b/backend/src/deliverables/dto/deliverable-response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeliverableResponseDto {
+  @ApiProperty({ description: 'UUID of the deliverable' })
+  deliverableId!: string;
+
+  @ApiProperty({ description: 'Unique deliverable name' })
+  name!: string;
+
+  @ApiProperty({ description: 'Top-level category weight' })
+  categoryWeight!: number;
+
+  @ApiProperty({ description: 'Deliverable weight within its category' })
+  subWeight!: number;
+
+  @ApiProperty({ description: 'Overall contribution percentage' })
+  deliverablePercentage!: number;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt!: Date;
+
+  @ApiProperty({ description: 'Last update timestamp', nullable: true })
+  updatedAt!: Date | null;
+}
+
+export class PaginatedDeliverablesDto {
+  @ApiProperty({ type: [DeliverableResponseDto] })
+  data!: DeliverableResponseDto[];
+
+  @ApiProperty({ description: 'Total number of matching deliverables' })
+  total!: number;
+
+  @ApiProperty({ description: 'Current page index (1-based)' })
+  page!: number;
+
+  @ApiProperty({ description: 'Page size' })
+  limit!: number;
+}

--- a/backend/src/deliverables/dto/list-deliverables-query.dto.ts
+++ b/backend/src/deliverables/dto/list-deliverables-query.dto.ts
@@ -1,0 +1,29 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class ListDeliverablesQueryDto {
+  @ApiPropertyOptional({
+    description: '1-based page index',
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page = 1;
+
+  @ApiPropertyOptional({
+    description: 'Page size',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit = 20;
+}

--- a/backend/src/deliverables/dto/update-deliverable.dto.ts
+++ b/backend/src/deliverables/dto/update-deliverable.dto.ts
@@ -1,0 +1,44 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, Max, Min } from 'class-validator';
+
+export class UpdateDeliverableDto {
+  @ApiPropertyOptional({
+    description: 'Top-level category weight in the final grade formula',
+    example: 0.5,
+    minimum: 0,
+    maximum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  categoryWeight?: number;
+
+  @ApiPropertyOptional({
+    description: 'Deliverable weight within its category',
+    example: 0.35,
+    minimum: 0,
+    maximum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  subWeight?: number;
+
+  @ApiPropertyOptional({
+    description: 'Overall contribution percentage of the deliverable',
+    example: 17.5,
+    minimum: 0,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  deliverablePercentage?: number;
+}

--- a/backend/src/deliverables/schemas/deliverable.schema.ts
+++ b/backend/src/deliverables/schemas/deliverable.schema.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from 'crypto';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type DeliverableDocument = HydratedDocument<Deliverable>;
+
+@Schema({ timestamps: true })
+export class Deliverable {
+  @Prop({ type: String, default: () => randomUUID(), unique: true })
+  deliverableId!: string;
+
+  @Prop({ type: String, required: true, unique: true, trim: true })
+  name!: string;
+
+  @Prop({ type: Number, required: true, min: 0, max: 1 })
+  categoryWeight!: number;
+
+  @Prop({ type: Number, required: true, min: 0, max: 1 })
+  subWeight!: number;
+
+  @Prop({ type: Number, required: true, min: 0, max: 100 })
+  deliverablePercentage!: number;
+}
+
+export const DeliverableSchema = SchemaFactory.createForClass(Deliverable);

--- a/backend/src/grades/grades.module.ts
+++ b/backend/src/grades/grades.module.ts
@@ -11,10 +11,6 @@ import {
   StudentFinalGradeSchema,
 } from './schemas/grade-records.schema';
 import {
-  Deliverable,
-  DeliverableSchema,
-} from './schemas/deliverable.schema';
-import {
   DeliverableEvaluation,
   DeliverableEvaluationSchema,
 } from './schemas/deliverable-evaluation.schema';
@@ -30,14 +26,15 @@ import {
   StoryPointRecord,
   StoryPointRecordSchema,
 } from '../story-points/schemas/story-point-record.schema';
+import { DeliverablesModule } from '../deliverables/deliverables.module';
 
 @Module({
   imports: [
+    DeliverablesModule,
     MongooseModule.forFeature([
       { name: StudentFinalGrade.name, schema: StudentFinalGradeSchema },
       { name: GroupFinalGrade.name, schema: GroupFinalGradeSchema },
       { name: GradeHistoryEntry.name, schema: GradeHistoryEntrySchema },
-      { name: Deliverable.name, schema: DeliverableSchema },
       { name: DeliverableEvaluation.name, schema: DeliverableEvaluationSchema },
       { name: SprintEvaluation.name, schema: SprintEvaluationSchema },
       { name: SprintConfig.name, schema: SprintConfigSchema },

--- a/backend/src/grades/grades.service.spec.ts
+++ b/backend/src/grades/grades.service.spec.ts
@@ -291,7 +291,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(2),
       });
 
-      const query: ListGradeHistoryQueryDto = {};
+      const query = new ListGradeHistoryQueryDto();
 
       // Act
       const result = await service.getGradeHistory(groupId, query);
@@ -336,7 +336,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(0),
       });
 
-      const query: ListGradeHistoryQueryDto = {};
+      const query = new ListGradeHistoryQueryDto();
 
       // Act & Assert
       await expect(service.getGradeHistory(groupId, query)).rejects.toThrow(
@@ -375,7 +375,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(1),
       });
 
-      const query: ListGradeHistoryQueryDto = { page: 0, limit: 20 };
+      const query = { page: 0, limit: 20 } as ListGradeHistoryQueryDto;
 
       // Act
       const result = await service.getGradeHistory(groupId, query);
@@ -405,7 +405,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(0),
       });
 
-      const query: ListGradeHistoryQueryDto = { page: 1, limit: 200 };
+      const query = { page: 1, limit: 200 } as ListGradeHistoryQueryDto;
 
       // Act & Assert
       // Actual implementation: no cap enforced in normalizePagination
@@ -431,7 +431,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(100),
       });
 
-      const query: ListGradeHistoryQueryDto = { page: 2, limit: 10 };
+      const query = { page: 2, limit: 10 } as ListGradeHistoryQueryDto;
 
       // Act
       const result = await service.getGradeHistory(groupId, query);
@@ -479,7 +479,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(3),
       });
 
-      const query: ListGradeHistoryQueryDto = {};
+      const query = new ListGradeHistoryQueryDto();
 
       // Act
       const result = await service.getGradeHistory(groupId, query);
@@ -524,7 +524,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(1),
       });
 
-      const query: ListGradeHistoryQueryDto = {};
+      const query = new ListGradeHistoryQueryDto();
 
       // Act
       await service.getGradeHistory(groupId, query);
@@ -556,7 +556,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(1),
       });
 
-      const query: ListGradeHistoryQueryDto = {};
+      const query = new ListGradeHistoryQueryDto();
 
       // Act
       const result = await service.getGradeHistory(groupId, query);
@@ -601,7 +601,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(1),
       });
 
-      const query: ListGradeHistoryQueryDto = {};
+      const query = new ListGradeHistoryQueryDto();
 
       // Act
       const result = await service.getGradeHistory('group-id', query);
@@ -671,7 +671,7 @@ describe('GradesService', () => {
         exec: jest.fn().mockResolvedValue(1),
       });
 
-      const query: ListGradeHistoryQueryDto = { page: 0, limit: 20 };
+      const query = { page: 0, limit: 20 } as ListGradeHistoryQueryDto;
 
       // Act
       const result = await service.getGradeHistory('group-id', query);

--- a/backend/src/grades/grades.service.ts
+++ b/backend/src/grades/grades.service.ts
@@ -29,7 +29,7 @@ import {
 import {
   Deliverable,
   DeliverableDocument,
-} from './schemas/deliverable.schema';
+} from '../deliverables/schemas/deliverable.schema';
 import {
   DeliverableEvaluation,
   DeliverableEvaluationDocument,

--- a/backend/src/grades/schemas/deliverable.schema.ts
+++ b/backend/src/grades/schemas/deliverable.schema.ts
@@ -1,28 +1,5 @@
-import { randomUUID } from 'crypto';
-import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument } from 'mongoose';
-
-export type DeliverableDocument = HydratedDocument<Deliverable>;
-
-@Schema({ timestamps: true })
-export class Deliverable {
-  @Prop({ type: String, default: () => randomUUID(), unique: true })
-  deliverableId!: string;
-
-  @Prop({ type: String, required: true, unique: true })
-  name!: string;
-
-  /** Weight of the category this deliverable belongs to (e.g. 0.5 for Documents 50%). */
-  @Prop({ type: Number, required: true, min: 0, max: 1 })
-  categoryWeight!: number;
-
-  /** Weight of this deliverable within its category (e.g. 0.35 for SoW within Documents). */
-  @Prop({ type: Number, required: true, min: 0, max: 1 })
-  subWeight!: number;
-
-  /** Overall percentage contribution of this deliverable to the final grade (0–100). */
-  @Prop({ type: Number, required: true, min: 0, max: 100 })
-  deliverablePercentage!: number;
-}
-
-export const DeliverableSchema = SchemaFactory.createForClass(Deliverable);
+export {
+  Deliverable,
+  DeliverableSchema,
+} from '../../deliverables/schemas/deliverable.schema';
+export type { DeliverableDocument } from '../../deliverables/schemas/deliverable.schema';


### PR DESCRIPTION
Introduce a full Deliverables feature: adds module, controller, service, DTOs, Mongoose schema and comprehensive unit tests. Integrates DeliverablesModule into AppModule and GradesModule and refactors grades to import/re-export the shared deliverable schema from the new module. Service implements transactional create/update with uniqueness and percentage-budget validations, logging, and error mapping; controller exposes list/create/update endpoints with role guards and correlation/actor handling. Also includes small test adjustments in grades specs (query DTO instantiation/casting).

## Summary
Implements Issue #142 by introducing a standalone `deliverables` backend module with DB-backed create, list, and update flows, then rewires `grades` to consume the shared `Deliverable` model from that module. This establishes the D1 foundation needed by later rubric, sprint-config, and deliverable-evaluation work.

Closes #142

---

## Type of Change
- [x] Feature (new endpoint or business logic)
- [ ] Bug fix
- [x] Refactor (no behavior change)
- [ ] Configuration / infrastructure
- [ ] Background job / scheduled task
- [ ] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [x] Test-only change

---

## Scope of Change

**Backend:**
- Controller(s): `backend/src/deliverables/deliverables.controller.ts`
- Use case(s) / service(s): `backend/src/deliverables/deliverables.service.ts`
- Repository / DB layer: `backend/src/deliverables/deliverables.module.ts`, `backend/src/grades/grades.module.ts`
- Schema / migration: `backend/src/deliverables/schemas/deliverable.schema.ts`, `backend/src/grades/schemas/deliverable.schema.ts`
- OpenAPI spec file(s): None updated in this PR

**Frontend:** (if applicable)
- Component(s): N/A
- API client / DTO: N/A

**Infrastructure / Config:** (if applicable)
- `backend/src/app.module.ts` to register `DeliverablesModule`

---

## API Contract Alignment

| Field | Value |
|---|---|
| Endpoint | `GET /deliverables`, `POST /deliverables`, `PATCH /deliverables/:deliverableId` |
| OperationId | `listDeliverables`, `createDeliverable`, `updateDeliverableWeights` |
| OpenAPI file | `process1.yaml` |
| Spec updated in this PR | No |

- [x] Response shape matches OpenAPI schema exactly
- [ ] All documented status codes are reachable via implementation
- [x] No fields added to response that are not in the spec
- [x] groupId / actorId extracted from JWT — NOT from request body (if applicable)

---

## Clean Architecture Checklist

**Infrastructure / API layer:**
- [ ] Auth guard behavior matches status code matrix in issue
- [x] Controller returns contract-compliant response shape
- [x] Input validation rules enforced (required fields, UUID format, enum values)

**Application / Use Case layer:**
- [x] Use case orchestrates all validations before any DB write
- [x] Sensitive fields never exposed in response DTOs
- [x] Error mapping is deterministic — same input always produces same error code

**Domain / Repository layer:**
- [x] Repository queries enforce correct domain filters (role scoping, ownership)
- [x] Concurrency / uniqueness constraints protected at DB level, not only application level
- [x] All DB failures caught and mapped to generic 500 — no raw DB errors reach the client

---

## Test Evidence

**Unit tests:**
- [x] Happy path covered
- [x] All business-rule failure cases covered (see Section 11 of issue)
- [x] Repository failure mapping tested

**Controller tests:**
- [ ] 401 unauthorized (missing/invalid JWT)
- [ ] 403 forbidden (wrong role or ownership mismatch)
- [x] Success response shape and status code
- [ ] Validation error response (400)

**Integration / E2E tests:**
- [ ] Happy flow end-to-end
- [ ] Conflict / locked / not-found flow end-to-end
- [ ] Contract parity with OpenAPI verified

**Test file locations:**
- Unit: `backend/src/deliverables/deliverables.service.spec.ts`
- Controller: `backend/src/deliverables/deliverables.controller.spec.ts`
- E2E: Not added in this PR

**Test run output:**
- `npm run build:docker` ✅
- `npm test -- --runTestsByPath src/deliverables/deliverables.service.spec.ts src/deliverables/deliverables.controller.spec.ts` ✅
- Result: `Test Suites: 2 passed, 2 total` / `Tests: 13 passed, 13 total`

---

## Status Code Matrix Verification

| Code | Scenario | Tested |
|---|---|---|
| 2xx | Happy path | ☑ |
| 400 | Validation failure | ☐ |
| 401 | Missing/invalid JWT | ☐ |
| 403 | Role or ownership mismatch | ☐ |
| 404 | PATCH deliverableId not found | ☑ |
| 409 | Duplicate deliverable name | ☑ |
| 422 | `deliverablePercentage` total exceeds 100 | ☑ |
| 500 | DB/internal failure | ☑ |

---

## Observability Checklist
- [x] Key business event is logged with correlationId / requestId
- [x] No secrets, tokens, hashes, or sensitive personal data in logs
- [x] 500 responses include actionable internal context in server logs
- [ ] Audit log entry written (if this is a POST, PATCH, or DELETE operation — requires Issue 47 to be merged first)

---

## Migration / Breaking Change Assessment
- [x] No database migration required
- [ ] Migration included and tested with rollback plan
- [x] No breaking change to API contract
- [ ] Breaking change — existing consumers notified: [describe]
- [x] Backward compatibility note: existing `grades/schemas/deliverable.schema.ts` is kept as a compatibility re-export while `grades` is rewired to the new module

---

## Out of Scope Confirmation
The following are explicitly out of scope for this PR and were not implemented:
- Deliverable deletion
- Rubric management
- Sprint-config API work beyond existing schema usage
- Deliverable evaluation endpoints
- OpenAPI spec file updates
- E2E coverage for the new endpoints

---

## Dependencies
- Blocked by: None
- Must be merged before: #143, #146, and any follow-up work that depends on a standalone deliverables module
- Requires Issue 47 (Audit logging) to be merged first: No

---

## Reviewer Notes
- The repo currently does not expose an `ADVISOR` role enum; read access is implemented with `Coordinator`, `Professor`, and `Admin` to match the existing auth model.
- `grades` was intentionally rewired to consume the shared deliverable model to avoid parallel schema drift.
- There is an unrelated pre-existing local modification in `backend/src/grades/grades.service.spec.ts` that was not touched by this PR’s implementation.

---

## Definition of Done Sign-off
- [x] Implementation merged with passing tests
- [ ] OpenAPI spec updated and aligned with implementation
- [ ] QA scenarios executed and evidenced above
- [x] PR description includes test evidence and status-matrix coverage
- [x] No TODO comments left in production code
- [x] No console.log or debug statements left in code
