### PR TITLE
test scripts edited

### DIFF
--- a/backend/src/groups/groups.module.ts
+++ b/backend/src/groups/groups.module.ts
@@ -12,13 +12,18 @@ import {
   CommitteeEvaluationSchema,
 } from './schemas/committee-evaluation.schema';
 import { CommitteesModule } from '../committees/committees.module';
+import { SubmissionsModule } from '../submissions/submissions.module';
 import { User, UserSchema } from '../users/data/user.schema';
-import { Committee, CommitteeSchema } from '../committees/schemas/committee.schema';
+import {
+  Committee,
+  CommitteeSchema,
+} from '../committees/schemas/committee.schema';
 import { TeamInvite, TeamInviteSchema } from './schemas/team-invite.schema';
 
 @Module({
   imports: [
     CommitteesModule,
+    SubmissionsModule,
     MongooseModule.forFeature([
       { name: Group.name, schema: GroupSchema },
       { name: Submission.name, schema: SubmissionSchema },

--- a/backend/src/groups/groups.service.spec.ts
+++ b/backend/src/groups/groups.service.spec.ts
@@ -7,6 +7,7 @@ import { Submission } from '../submissions/schemas/submission.schema';
 import { CommitteeEvaluation, EvaluationGrade } from './schemas/committee-evaluation.schema';
 import { CommitteeGradeStatus } from './dto/committee-grade-result.dto';
 import { Committee } from '../committees/schemas/committee.schema';
+import { TeamInvite } from './schemas/team-invite.schema';
 
 describe('GroupsService', () => {
   let service: GroupsService;
@@ -14,6 +15,7 @@ describe('GroupsService', () => {
   let mockSubmissionModel: any;
   let mockEvaluationModel: any;
   let mockCommitteeModel: any;
+  let mockTeamInviteModel: any;
 
   beforeEach(async () => {
     const mockGroup = {
@@ -33,6 +35,7 @@ describe('GroupsService', () => {
     mockSubmissionModel = { find: jest.fn() };
     mockEvaluationModel = { find: jest.fn() };
     mockCommitteeModel = { findOne: jest.fn() };
+    mockTeamInviteModel = { findOne: jest.fn(), find: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -42,6 +45,7 @@ describe('GroupsService', () => {
         { provide: getModelToken('User'), useValue: jest.fn() },
         { provide: getModelToken(CommitteeEvaluation.name), useValue: mockEvaluationModel },
         { provide: getModelToken(Committee.name), useValue: mockCommitteeModel },
+        { provide: getModelToken(TeamInvite.name), useValue: mockTeamInviteModel },
       ],
     }).compile();
 

--- a/backend/src/submissions/submissions.service.spec.ts
+++ b/backend/src/submissions/submissions.service.spec.ts
@@ -37,6 +37,7 @@ describe('SubmissionsService', () => {
 
   mockSubmissionModel.findById = mockFindById;
   mockSubmissionModel.find = jest.fn().mockReturnThis();
+  mockSubmissionModel.findOne = jest.fn();
   mockSubmissionModel.sort = jest.fn().mockReturnThis();
   mockSubmissionModel.exec = jest.fn();
 
@@ -73,6 +74,7 @@ describe('SubmissionsService', () => {
     jest.clearAllMocks();
     mockSave.mockReset();
     mockSubmissionModel.mockClear();
+    mockSubmissionModel.findOne.mockReset();
     mockFindById.mockReset();
     mockGroupModel.findOne.mockReset();
     mockUserModel.findById.mockReset();


### PR DESCRIPTION
## Summary

Restores a green backend unit test run after `GroupsService` began injecting `TeamInvite` and `SubmissionsService.validateSowEligibility` began using `submissionModel.findOne`, by extending Nest test providers and mocks. Imports `SubmissionsModule` into `GroupsModule` for module wiring and pins `cookie-parser` to `1.4.6` in `backend/package-lock.json` (exact version).

Closes #274

---

## Type of Change

- [ ] Feature (new endpoint or business logic)
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [x] Configuration / infrastructure
- [ ] Background job / scheduled task
- [ ] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [x] Test-only change

---

## Scope of Change

**Backend:**
- **Controller(s):** —
- **Use case(s) / service(s):** —
- **Repository / DB layer:** —
- **Schema / migration:** —
- **OpenAPI spec file(s):** —

**Files touched:**
- `backend/src/groups/groups.module.ts` — add `SubmissionsModule` to `imports`
- `backend/src/groups/groups.service.spec.ts` — register `getModelToken(TeamInvite.name)` mock
- `backend/src/submissions/submissions.service.spec.ts` — add `findOne` mock and reset in `beforeEach`
- `backend/package-lock.json` — `cookie-parser` resolved to exact `1.4.6`

**Frontend:** —

**Infrastructure / Config:** `backend/package-lock.json`

---

## API Contract Alignment

| Field | Value |
|---|---|
| Endpoint | N/A |
| OperationId | N/A |
| OpenAPI file | N/A |
| Spec updated in this PR | N/A |

- [ ] Response shape matches OpenAPI schema exactly
- [ ] All documented status codes are reachable via implementation
- [ ] No fields added to response that are not in the spec
- [ ] groupId / actorId extracted from JWT — NOT from request body (if applicable)

---

## Clean Architecture Checklist

**Infrastructure / API layer:**
- [ ] Auth guard behavior matches status code matrix in issue
- [ ] Controller returns contract-compliant response shape
- [ ] Input validation rules enforced (required fields, UUID format, enum values)

**Application / Use Case layer:**
- [ ] Use case orchestrates all validations before any DB write
- [ ] Sensitive fields never exposed in response DTOs
- [ ] Error mapping is deterministic — same input always produces same error code

**Domain / Repository layer:**
- [ ] Repository queries enforce correct domain filters (role scoping, ownership)
- [ ] Concurrency / uniqueness constraints protected at DB level, not only application level
- [ ] All DB failures caught and mapped to generic 500 — no raw DB errors reach the client

_Not applicable — no production controller/service logic changes in this diff._

---

## Test Evidence

**Unit tests:**
- [x] Happy path covered (existing suites; mocks updated so tests run)
- [ ] All business-rule failure cases covered (see Section 11 of issue)
- [ ] Repository failure mapping tested

**Controller tests:**
- [ ] 401 unauthorized (missing/invalid JWT)
- [ ] 403 forbidden (wrong role or ownership mismatch)
- [ ] Success response shape and status code
- [ ] Validation error response (400)

**Integration / E2E tests:**
- [ ] Happy flow end-to-end
- [ ] Conflict / locked / not-found flow end-to-end
- [ ] Contract parity with OpenAPI verified

**Test file locations:**
- **Unit:** `backend/src/groups/groups.service.spec.ts`, `backend/src/submissions/submissions.service.spec.ts`
- **Controller:** —
- **E2E:** —

**Test run output:**

Test Suites: 32 passed, 32 total
Tests:       479 passed, 479 total
Snapshots:   0 total
Time:        6.001 s