### PR TITLE
fixed search fields on bugged fields

### DIFF
--- a/frontend/src/components/dashboard/StoryPointsPanel.jsx
+++ b/frontend/src/components/dashboard/StoryPointsPanel.jsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import styles from '../../pages/DashboardPage.module.css';
 import storyPointsService from '../../utils/storyPointsService';
+import EntitySearchSelect from '../EntitySearchSelect';
+import apiClient from '../../utils/apiClient';
+import apiConfig from '../../config/api';
 
 const SOURCE_META = {
   COORDINATOR_OVERRIDE: { label: 'COORDINATOR_OVERRIDE', className: styles.sourceWarning },
@@ -12,6 +15,7 @@ const SOURCE_META = {
 const StoryPointsPanel = ({ canOverride }) => {
   const [groupId, setGroupId] = useState('');
   const [sprintId, setSprintId] = useState('');
+  const [sprintOptions, setSprintOptions] = useState([]);
   const [records, setRecords] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
@@ -22,6 +26,13 @@ const StoryPointsPanel = ({ canOverride }) => {
     () => groupId.trim().length > 0 && sprintId.trim().length > 0,
     [groupId, sprintId],
   );
+
+  useEffect(() => {
+    apiClient
+      .get(apiConfig.endpoints.sprints, { params: { page: 1, limit: 100 } })
+      .then((r) => setSprintOptions(r.data?.data ?? []))
+      .catch(() => setSprintOptions([]));
+  }, []);
 
   useEffect(
     () => () => {
@@ -115,18 +126,28 @@ const StoryPointsPanel = ({ canOverride }) => {
     <div className={styles.tableWrapper}>
       <h3 style={{ color: '#94a3b8', marginBottom: '12px' }}>Sprint Story Points</h3>
       <div className={styles.storyPointControls}>
-        <input
-          className={styles.storyPointInput}
-          placeholder="Group UUID"
+        <EntitySearchSelect
+          endpoint={apiConfig.endpoints.groups}
+          buildParams={(q) => ({ name: q, page: 1, limit: 20 })}
+          getItems={(res) => res.data}
+          returnField="groupId"
+          displayField="groupName"
           value={groupId}
-          onChange={(event) => setGroupId(event.target.value)}
+          onChange={setGroupId}
+          placeholder="Search group by name"
         />
-        <input
+        <select
           className={styles.storyPointInput}
-          placeholder="Sprint UUID"
           value={sprintId}
           onChange={(event) => setSprintId(event.target.value)}
-        />
+        >
+          <option value="">Select sprint…</option>
+          {sprintOptions.map((s) => (
+            <option key={s.sprintId} value={s.sprintId}>
+              {s.sprintId} ({s.targetStoryPoints} pts)
+            </option>
+          ))}
+        </select>
         <button className={styles.smallButton} onClick={loadRecords} disabled={isLoading}>
           {isLoading ? 'Loading...' : 'Load'}
         </button>

--- a/frontend/src/pages/admin/CommitteeDetailPage.jsx
+++ b/frontend/src/pages/admin/CommitteeDetailPage.jsx
@@ -194,8 +194,6 @@ function AdvisorsTab({ committeeId, onAdvisorsLoaded }) {
   const [advisorId, setAdvisorId] = useState('')
   const [source, setSource] = useState('PRIMARY_ADVISOR')
   const [addStatus, setAddStatus] = useState({ message: '', error: '', loading: false })
-  const [advisorList, setAdvisorList] = useState([])
-  const [advisorsLoading, setAdvisorsLoading] = useState(true)
 
   const load = useCallback(async (p = 1) => {
     setLoading(true)
@@ -218,19 +216,16 @@ function AdvisorsTab({ committeeId, onAdvisorsLoaded }) {
 
   useEffect(() => { load(1) }, [load])
 
-  useEffect(() => {
-    apiClient.get(apiConfig.endpoints.advisors, { params: { page: 1, limit: 100 } })
-      .then(r => setAdvisorList(r.data?.data ?? []))
-      .catch(() => setAdvisorList([]))
-      .finally(() => setAdvisorsLoading(false))
-  }, [])
-
   const handleAdd = async (e) => {
     e.preventDefault()
+    if (!advisorId) {
+      setAddStatus({ loading: false, message: '', error: 'Select an advisor from the search results first.' })
+      return
+    }
     setAddStatus({ loading: true, message: '', error: '' })
     try {
       await apiClient.post(apiConfig.endpoints.committeeAdvisors(committeeId), {
-        advisorUserId: advisorId,
+        advisorId,
         assignmentSource: source,
       })
       setAddStatus({ loading: false, message: 'Advisor added.', error: '' })
@@ -297,21 +292,18 @@ function AdvisorsTab({ committeeId, onAdvisorsLoaded }) {
         onSubmit={handleAdd}
         className="flex flex-col sm:flex-row gap-2 border-t border-[#1e293b] pt-4"
       >
-        <select
-          value={advisorId}
-          onChange={(e) => setAdvisorId(e.target.value)}
-          required
-          className="flex-1 rounded-xl border border-[#1e293b] bg-[#111827] px-4 py-2.5 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-600/60 disabled:opacity-50"
-        >
-          <option value="">
-            {advisorsLoading ? 'Loading advisors…' : 'Select advisor'}
-          </option>
-          {advisorList.map((a) => (
-            <option key={a.advisorId} value={a.advisorId}>
-              {a.name ? `${a.name} (${a.email})` : a.email}
-            </option>
-          ))}
-        </select>
+        <div className="flex-1">
+          <EntitySearchSelect
+            endpoint={apiConfig.endpoints.userSearch}
+            searchField="email"
+            returnField="_id"
+            displayField="email"
+            value={advisorId}
+            onChange={setAdvisorId}
+            placeholder="Search advisor by email"
+            required
+          />
+        </div>
         <select
           value={source}
           onChange={(e) => setSource(e.target.value)}
@@ -493,6 +485,21 @@ function GradingScopeTab({ committeeId, advisorList }) {
   const [totalPages, setTotalPages] = useState(1)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  const [advisorDisplayMap, setAdvisorDisplayMap] = useState({})
+
+  useEffect(() => {
+    apiClient.get(apiConfig.endpoints.advisors, { params: { page: 1, limit: 100 } })
+      .then((r) => {
+        const list = r.data?.data ?? []
+        const map = {}
+        list.forEach((a) => {
+          const key = a.advisorId || a._id
+          if (key) map[key] = a.name ? `${a.name} (${a.email})` : (a.email ?? key)
+        })
+        setAdvisorDisplayMap(map)
+      })
+      .catch(() => {})
+  }, [])
 
   const loadScope = useCallback(async (advisorId, p = 1) => {
     if (!advisorId) return
@@ -534,7 +541,7 @@ function GradingScopeTab({ committeeId, advisorList }) {
             const uid = a.advisorUserId || a._id
             return (
               <option key={uid} value={uid}>
-                {uid}
+                {advisorDisplayMap[uid] || uid}
               </option>
             )
           })}


### PR DESCRIPTION
## Summary
Improves coordinator/admin UX on the dashboard **Sprint story points** panel (searchable group + sprint dropdown) and on **Committee detail** (correct `advisorId` payload for add-advisor, searchable advisor by email, friendlier grading-scope advisor labels).

Closes #272 

---

## Type of Change
- [ ] Feature (new endpoint or business logic)
- [x] Bug fix
- [x] Refactor (no behavior change)
- [ ] Configuration / infrastructure
- [ ] Background job / scheduled task
- [ ] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

_(Also UX/feature polish on top of the committee contract fix.)_

---

## Scope of Change

**Backend:**
- Controller(s): _None_
- Use case(s) / service(s): _None_
- Repository / DB layer: _None_
- Schema / migration: _None_
- OpenAPI spec file(s): _None (no contract change; frontend aligned to existing DTO)_

**Frontend:**
- Component(s): `frontend/src/components/dashboard/StoryPointsPanel.jsx`
- Page(s): `frontend/src/pages/admin/CommitteeDetailPage.jsx` (`AdvisorsTab`, `GradingScopeTab`)
- API client / DTO: Uses existing `apiClient` + `apiConfig.endpoints` (`groups`, `sprints`, `userSearch`, `committeeAdvisors`)

**Infrastructure / Config:** _N/A_

---

## API Contract Alignment

| Field | Value |
|---|---|
| Endpoint | `POST /committees/{committeeId}/advisors` |
| OperationId | `addCommitteeAdvisor` |
| OpenAPI file | `docs/api/api-specs/process5.yaml` |
| Spec updated in this PR | No |

- [x] Request body matches DTO: `advisorId`, `assignmentSource` (`AddCommitteeAdvisorDto`)
- [x] No backend changes required for story points / group search / sprint list (existing `GET /groups`, `GET /sprints`)

---

## Clean Architecture Checklist

**Infrastructure / API layer:** N/A (frontend-only PR)

**Application / Use Case layer:**
- [x] Client sends fields the backend validates (`advisorId` not `advisorUserId`)

**Domain / Repository layer:** N/A

---

## Test Evidence

**Manual / UI:**
- [ ] Dashboard → Sprint story points: search group by name, pick sprint from dropdown, **Load** returns data as before
- [ ] Committee detail → Advisors: search advisor by email, add with PRIMARY/JURY source → success path
- [ ] Committee detail → Grading scope: advisor dropdown shows label vs raw id

Test run output:

Test Suites: 32 passed, 32 total
Tests: 479 passed, 479 total
Snapshots: 0 total
Time: 6.001 s
---

## Status Code Matrix Verification

_(Frontend consumer only; spot-check in browser/network tab)_

| Code | Scenario | Tested |
|---|---|---|
| 200 | Add committee advisor success | ☐ |
| 400 | Validation (e.g. missing `advisorId`) | ☐ |
| 401/403 | Auth | ☐ |

---

## Observability Checklist
- [x] No new logging on frontend required for this change
- [x] No secrets in client-visible payloads beyond existing JWT usage

---

## Migration / Breaking Change Assessment
- [x] No database migration required
- [x] No breaking change to public API (frontend fixed to match existing API)
- [x] Backward compatibility: same endpoints; committee POST body field name corrected for existing servers

---

## Out of Scope Confirmation
- Backend validation relaxation (e.g. `advisorId` format vs Mongo `ObjectId` vs UUID) — not changed here
- Pagination/infinite scroll for sprints beyond first 100
- Automated E2E for dashboard/committee flows unless requested

---

## Dependencies
- Blocked by: _None_

---

## Definition of Done Sign-off
- [ ] Lint/tests passing (evidence pasted)
- [ ] Manual scenarios checked above
- [ ] No TODO/debug noise added