### PR TITLE
fix(submissions): enforce professor access control on list and document download endpoints

### DIFF
--- a/backend/src/submissions/submissions.controller.ts
+++ b/backend/src/submissions/submissions.controller.ts
@@ -190,7 +190,13 @@ export class SubmissionsController {
       if (!submission) throw new ForbiddenException('Submission not found.');
       await this.submissionsService.assertAuthorizedGroupMember(req.user, submission.groupId);
     }
-    // Professor, Coordinator, Admin: no group membership check for download
+    // Professor: must be the advisor or a jury member of the group
+    if (userRole === Role.Professor) {
+      const submission = await this.submissionsService.findById(submissionId);
+      if (!submission) throw new ForbiddenException('Submission not found.');
+      await this.submissionsService.assertProfessorCanAccessSubmission(submission, req.user.userId);
+    }
+    // Coordinator, Admin: unrestricted
 
     const file = await this.submissionsService.getDocumentForDownload(
       submissionId,
@@ -238,6 +244,17 @@ export class SubmissionsController {
           'You can only access data from your own group.',
         );
       }
+    }
+
+    if (userRole === Role.Professor) {
+      if (groupId) {
+        // Validate professor is authorized for the requested group
+        const stub = { groupId } as any;
+        await this.submissionsService.assertProfessorCanAccessSubmission(stub, req.user.userId);
+        return this.submissionsService.findAll(groupId);
+      }
+      // No groupId filter: return all submissions the professor can access
+      return this.submissionsService.findAllForProfessor(req.user.userId);
     }
 
     return this.submissionsService.findAll(groupId);

--- a/backend/src/submissions/submissions.service.ts
+++ b/backend/src/submissions/submissions.service.ts
@@ -186,6 +186,32 @@ export class SubmissionsService {
     return this.submissionModel.find(query).sort({ createdAt: -1 }).exec();
   }
 
+  /** Returns all submissions the professor can access:
+   *  - Groups where professor is the assigned advisor
+   *  - Groups belonging to committees where professor is a jury member
+   */
+  async findAllForProfessor(professorUserId: string) {
+    // Collect groupIds from committees the professor is a jury member of
+    const committees = await this.committeeModel
+      .find({ 'jury.userId': professorUserId })
+      .exec();
+    const committeeGroupIds = committees.flatMap((c) => this.getCommitteeGroupIds(c));
+
+    // Collect groupIds where professor is the assigned advisor
+    const advisedGroups = await this.groupModel
+      .find({ assignedAdvisorId: professorUserId })
+      .exec();
+    const advisedGroupIds = advisedGroups.map((g) => String(g.groupId));
+
+    const allGroupIds = [...new Set([...committeeGroupIds, ...advisedGroupIds])];
+    if (allGroupIds.length === 0) return [];
+
+    return this.submissionModel
+      .find({ groupId: { $in: allGroupIds } })
+      .sort({ createdAt: -1 })
+      .exec();
+  }
+
   async uploadDocumentForUser(userId: string, submissionId: string, file: Express.Multer.File) {
     if (!isValidObjectId(submissionId)) {
       throw new NotFoundException('Submission not found.');


### PR DESCRIPTION
## Summary

Professors without an advisor assignment or jury membership could call `GET /submissions` and `GET /submissions/:id/documents/:index/download` without any ownership check, seeing and downloading submissions from unrelated groups. This PR enforces professor-specific access control on both endpoints and adds a dedicated `findAllForProfessor` service method.

Closes #[ISSUE_NUMBER]

---

## Type of Change
- [x] Bug fix

---

## Scope of Change

**Backend:**
- Controller(s): `backend/src/submissions/submissions.controller.ts`
- Use case(s) / service(s): `backend/src/submissions/submissions.service.ts`
- Repository / DB layer: Queries against `Group` (`assignedAdvisorId`) and `Committee` (`jury.userId`) collections
- Schema / migration: None
- OpenAPI spec file(s): N/A

---

## API Contract Alignment

| Field | Value |
|---|---|
| Endpoint | `GET /submissions` |
| OperationId | findAll |
| Spec updated in this PR | No |

| Field | Value |
|---|---|
| Endpoint | `GET /submissions/:submissionId/documents/:documentIndex` |
| OperationId | downloadDocument |
| Spec updated in this PR | No |

- [x] groupId / actorId extracted from JWT — NOT from request body

---

## Clean Architecture Checklist

**Infrastructure / API layer:**
- [x] Auth guard behavior matches status code matrix
- [x] Controller returns contract-compliant response shape

**Application / Use Case layer:**
- [x] Use case orchestrates all validations before any DB read

**Domain / Repository layer:**
- [x] Repository queries enforce correct domain filters (role scoping, ownership)

---

## Status Code Matrix Verification

| Code | Scenario | Tested |
|---|---|---|
| 200 | Professor requests list of their own groups' submissions | ☐ |
| 200 | Professor downloads document from an advised group | ☐ |
| 403 | Professor requests `groupId` they do not advise or jury | ☐ |
| 403 | Professor downloads document from unrelated group | ☐ |
| 401 | Missing/invalid JWT | ☐ |

---

## Out of Scope Confirmation

The following are explicitly out of scope for this PR and were not implemented:
- Pagination of the professor submissions list
- Audit logging (depends on Issue #47)

---

## Migration / Breaking Change Assessment
- [x] No database migration required
- [x] No breaking change to API contract

---

## Reviewer Notes
- `assertProfessorCanAccessSubmission` is reused for both the single-document download guard and the `groupId`-filtered list query to keep the logic in one place.
- `findAllForProfessor` performs two parallel-intent queries (advisor groups + committee groups) and deduplicates with `Set` before querying submissions.