### PR TITLE
JIRA discovery, PR author checks, professor scope

### DIFF
--- a/backend/src/auth/guards/roles.guard.ts
+++ b/backend/src/auth/guards/roles.guard.ts
@@ -23,8 +23,15 @@ export class RolesGuard implements CanActivate {
     if (!user) {
       throw new ForbiddenException('You must be logged in');
     }
-    if (!requiredRoles.includes(user.role)) {
-      throw new ForbiddenException('Insufficient permissions');
+    const callerRole = (user.role ?? '').toString();
+    const callerRoleLc = callerRole.toLowerCase();
+    const matched = requiredRoles.some(
+      (r) => r === callerRole || r.toLowerCase() === callerRoleLc,
+    );
+    if (!matched) {
+      throw new ForbiddenException(
+        `Insufficient permissions. Required: ${requiredRoles.join(', ')}. Your role: ${callerRole || '<none>'}.`,
+      );
     }
     return true;
   }

--- a/backend/src/groups/groups.controller.ts
+++ b/backend/src/groups/groups.controller.ts
@@ -54,13 +54,38 @@ export class GroupsController {
     private readonly committeesService: CommitteesService,
   ) {}
 
-  @ApiOperation({ summary: 'List groups with optional name filter (Admin, Coordinator)' })
+  @ApiOperation({
+    summary:
+      'List groups. Admin/Coordinator see all; Professor sees groups they advise; TeamLeader/Student see only their own group.',
+  })
   @ApiOkResponse({ description: 'Paginated list of groups' })
   @Get()
-  @Roles(Role.Admin, Role.Coordinator)
+  @Roles(Role.Admin, Role.Coordinator, Role.Professor, Role.TeamLeader, Role.Student)
   @HttpCode(HttpStatus.OK)
-  async listGroups(@Query() query: ListGroupsQueryDto) {
-    return this.groupsService.findAll(query.page, query.limit, query.name);
+  async listGroups(
+    @Query() query: ListGroupsQueryDto,
+    @Request() req: RequestWithUser,
+  ) {
+    const callerId = req.user.userId ?? req.user.sub ?? req.user._id ?? '';
+    const role = (req.user.role ?? '').toLowerCase();
+
+    if (role === 'teamleader' || role === 'student') {
+      // Members only see their own group. user.teamId === groupId in this app.
+      const ownGroupId = (req.user as any).groupId ?? (req.user as any).teamId ?? null;
+      if (!ownGroupId) {
+        return { data: [], total: 0, page: query.page ?? 1, limit: query.limit ?? 20 };
+      }
+      return this.groupsService.findAll(
+        query.page,
+        query.limit,
+        query.name,
+        undefined,
+        [ownGroupId],
+      );
+    }
+
+    const advisorScope = role === 'professor' ? callerId : undefined;
+    return this.groupsService.findAll(query.page, query.limit, query.name, advisorScope);
   }
 
   // ─── Student: create own team ─────────────────────────────────────────────

--- a/backend/src/groups/groups.service.ts
+++ b/backend/src/groups/groups.service.ts
@@ -110,6 +110,10 @@ export class GroupsService {
     page: number,
     limit: number,
     name?: string,
+    /** When provided, restricts results to groups advised by this user. */
+    advisorUserId?: string,
+    /** When provided, restricts results to these specific groupIds. */
+    onlyGroupIds?: string[],
   ): Promise<{
     data: Array<{
       groupId: string;
@@ -127,6 +131,18 @@ export class GroupsService {
     if (name?.trim()) {
       const escaped = name.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       filter.groupName = { $regex: escaped, $options: 'i' };
+    }
+    if (advisorUserId) {
+      filter.$or = [
+        { advisorUserId },
+        { assignedAdvisorId: advisorUserId },
+      ];
+    }
+    if (onlyGroupIds) {
+      if (onlyGroupIds.length === 0) {
+        return { data: [], total: 0, page, limit };
+      }
+      filter.groupId = { $in: onlyGroupIds };
     }
     const skip = (page - 1) * limit;
     const [docs, total] = await Promise.all([

--- a/backend/src/teams/dto/jira-discover.dto.ts
+++ b/backend/src/teams/dto/jira-discover.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class JiraDiscoverDto {
+  @ApiProperty({ example: 'mycompany.atlassian.net' })
+  @IsNotEmpty()
+  @IsString()
+  @Transform(({ value }) =>
+    typeof value === 'string'
+      ? value.replace(/^https?:\/\//, '').replace(/\/$/, '').trim()
+      : value,
+  )
+  jiraDomain!: string;
+
+  @ApiProperty({ example: 'leader@mycompany.com' })
+  @IsNotEmpty()
+  @IsEmail()
+  @Transform(({ value }) => value?.trim().toLowerCase())
+  jiraEmail!: string;
+
+  @ApiProperty({ example: 'ATATT3xFfGF0...' })
+  @IsNotEmpty()
+  @IsString()
+  @Transform(({ value }) => value?.trim())
+  jiraApiToken!: string;
+
+  @ApiPropertyOptional({ example: 'TES' })
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => value?.trim().toUpperCase())
+  jiraProjectKey?: string;
+}

--- a/backend/src/teams/schemas/sprint-story.schema.ts
+++ b/backend/src/teams/schemas/sprint-story.schema.ts
@@ -8,6 +8,8 @@ export enum GithubStatus {
   NO_BRANCH = 'no_branch',
   NO_PR = 'no_pr',
   PR_NOT_MERGED = 'pr_not_merged',
+  /** PR is merged but the author's GitHub username does not match the JIRA assignee's. */
+  AUTHOR_MISMATCH = 'author_mismatch',
   VERIFIED = 'verified',
 }
 
@@ -75,6 +77,10 @@ export class SprintStory {
 
   @Prop({ required: true, default: false })
   githubPrFound!: boolean;
+
+  /** GitHub login of whoever opened the merged PR (only set when one was found). */
+  @Prop({ type: String, default: null })
+  prAuthorLogin!: string | null;
 
   /** True when resolution=Done AND githubStatus=verified */
   @Prop({ type: Boolean, default: false })

--- a/backend/src/teams/teams-cron.service.ts
+++ b/backend/src/teams/teams-cron.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
@@ -10,7 +10,7 @@ import {
 } from '../story-points/schemas/sprint-config.schema';
 
 @Injectable()
-export class TeamsCronService {
+export class TeamsCronService implements OnApplicationBootstrap {
   private readonly logger = new Logger(TeamsCronService.name);
 
   constructor(
@@ -19,6 +19,25 @@ export class TeamsCronService {
     private sprintConfigModel: Model<SprintConfigDocument>,
     private readonly teamsSyncService: TeamsSyncService,
   ) {}
+
+  /**
+   * On boot, kick off a sync in the background so the UI shows fresh data
+   * without waiting until the next 02:00 UTC cron tick. We delay slightly so
+   * the rest of the app finishes wiring up first, and we never block startup.
+   * Disable by setting SKIP_BOOT_SYNC=1.
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    if (process.env.SKIP_BOOT_SYNC === '1') {
+      this.logger.log('Boot sync skipped (SKIP_BOOT_SYNC=1).');
+      return;
+    }
+    setTimeout(() => {
+      this.dailySync().catch((err) => {
+        this.logger.error(`Boot sync failed: ${err.message}`);
+      });
+    }, 5000);
+    this.logger.log('Boot sync scheduled (5s after startup).');
+  }
 
   /** Runs every day at 02:00 UTC */
   @Cron(CronExpression.EVERY_DAY_AT_2AM)

--- a/backend/src/teams/teams-sync.service.ts
+++ b/backend/src/teams/teams-sync.service.ts
@@ -276,18 +276,58 @@ export class TeamsSyncService {
       const issues = await this.fetchJiraIssues(team);
       const studentByAccountId = await this.buildAccountIdMap(team);
 
+      this.logger.log(
+        `[sync ${teamId}] fetched ${issues.length} issues from JIRA (${team.jiraDomain}/${team.jiraProjectKey}).`,
+      );
+
+      // Debug: dump first issue's raw fields so misconfig (wrong story-points
+      // field id, assignee shape) is obvious. Toggle with SYNC_DEBUG=1.
+      if (process.env.SYNC_DEBUG === '1' && issues.length > 0) {
+        const sample = issues[0];
+        const fieldKeys = Object.keys(sample.fields ?? {});
+        const storyPointsField = team.jiraStoryPointsField || 'customfield_10016';
+        this.logger.warn(
+          `[sync DEBUG] first issue ${sample.key}:\n` +
+            `  configured storyPointsField = "${storyPointsField}"\n` +
+            `  fields[${storyPointsField}] = ${JSON.stringify(sample.fields?.[storyPointsField])}\n` +
+            `  fields.assignee = ${JSON.stringify(sample.fields?.assignee)}\n` +
+            `  available field keys: ${fieldKeys.join(', ')}\n` +
+            `  any "customfield_*" with non-null value: ${fieldKeys
+              .filter((k) => k.startsWith('customfield_') && sample.fields[k] !== null && sample.fields[k] !== undefined)
+              .map((k) => `${k}=${JSON.stringify(sample.fields[k]).slice(0, 60)}`)
+              .join('; ') || '(none)'}`,
+        );
+      }
+
+      // Build a parallel map: studentId → githubUsername, so we can compare PR
+      // authors to the JIRA assignee's linked GitHub account.
+      const githubByStudentId = await this.buildGithubLoginMap(team);
+
       let linkedCount = 0;
       for (const issue of issues) {
-        if (await this.isLocked(teamId, issue.key)) continue;
-
-        const githubResult = team.githubRepositoryId
-          ? await this.verifyGithub(team, issue.key)
-          : { githubStatus: GithubStatus.NO_BRANCH, verifiedAt: null, branchFound: false, prFound: false };
+        if (await this.isLocked(teamId, issue.key)) {
+          this.logger.log(`  • ${issue.key}  [LOCKED — sprint already finalized, skipping]`);
+          continue;
+        }
 
         const assigneeAccountId: string | null = issue.fields?.assignee?.accountId ?? null;
         const assigneeStudentId = assigneeAccountId
           ? (studentByAccountId.get(assigneeAccountId) ?? null)
           : null;
+
+        const expectedAuthorLogin = assigneeStudentId
+          ? githubByStudentId.get(assigneeStudentId) ?? null
+          : null;
+
+        const githubResult = team.githubRepositoryId
+          ? await this.verifyGithub(team, issue.key, expectedAuthorLogin)
+          : {
+              githubStatus: GithubStatus.NO_BRANCH,
+              verifiedAt: null,
+              branchFound: false,
+              prFound: false,
+              prAuthorLogin: null,
+            };
 
         const resolution: string | null = issue.fields?.resolution?.name ?? null;
         const storyPointsField = team.jiraStoryPointsField || 'customfield_10016';
@@ -300,6 +340,31 @@ export class TeamsSyncService {
           resolution === 'Done' && githubResult.githubStatus === GithubStatus.VERIFIED;
 
         if (githubResult.branchFound || githubResult.prFound) linkedCount++;
+
+        const assigneeLabel = assigneeAccountId
+          ? assigneeStudentId
+            ? `student ${assigneeStudentId.slice(-6)}`
+            : `unmapped accountId ${assigneeAccountId.slice(-8)}`
+          : 'no assignee';
+        const authorTrace = githubResult.prAuthorLogin
+          ? `pr@${githubResult.prAuthorLogin}${
+              expectedAuthorLogin ? ` (expected @${expectedAuthorLogin})` : ' (assignee github not linked)'
+            }`
+          : '';
+        this.logger.log(
+          `  • ${issue.key.padEnd(10)}  ` +
+            `pts=${String(work).padEnd(3)}  ` +
+            `jira=${(resolution ?? 'open').padEnd(8)}  ` +
+            `github=${githubResult.githubStatus.padEnd(16)}  ` +
+            `complete=${isComplete ? 'YES' : 'no '}  ` +
+            `${assigneeLabel}` +
+            (authorTrace ? `  ${authorTrace}` : ''),
+        );
+        if (githubResult.githubStatus === GithubStatus.AUTHOR_MISMATCH) {
+          this.logger.warn(
+            `[sync ${teamId}] ${issue.key}: PR was authored by @${githubResult.prAuthorLogin} but JIRA assignee's linked GitHub is @${expectedAuthorLogin}. Issue NOT counted as complete.`,
+          );
+        }
 
         const jiraSprintId = this.extractJiraSprintId(issue);
 
@@ -320,6 +385,7 @@ export class TeamsSyncService {
               verifiedAt: githubResult.verifiedAt,
               githubBranchFound: githubResult.branchFound,
               githubPrFound: githubResult.prFound,
+              prAuthorLogin: githubResult.prAuthorLogin,
               isComplete,
               syncRunId,
               syncedAt,
@@ -329,7 +395,27 @@ export class TeamsSyncService {
         ).exec();
       }
 
-      this.logger.log(`Sync done for team ${teamId}. RunID: ${syncRunId}`);
+      // Summary tally
+      const fresh = await this.sprintStoryModel
+        .find({ teamId })
+        .select('githubStatus isComplete work assigneeStudentId')
+        .lean()
+        .exec();
+      const verified = fresh.filter((s) => s.githubStatus === GithubStatus.VERIFIED).length;
+      const completed = fresh.filter((s) => s.isComplete).length;
+      const unassigned = fresh.filter((s) => !s.assigneeStudentId).length;
+      const totalPoints = fresh
+        .filter((s) => s.isComplete)
+        .reduce((sum, s) => sum + (s.work ?? 0), 0);
+
+      this.logger.log(
+        `[sync ${teamId}] DONE: total=${issues.length} linked=${linkedCount} verified=${verified} complete=${completed} (${totalPoints} pts) unassigned=${unassigned}`,
+      );
+      if (unassigned > 0) {
+        this.logger.warn(
+          `[sync ${teamId}] ${unassigned} issue(s) have no mapped student — those students need to bind their JIRA accountId at /integrations.`,
+        );
+      }
       return { syncRunId, totalIssues: issues.length, linkedCount, syncedAt: syncedAt.toISOString() };
 
     } catch (error) {
@@ -660,7 +746,14 @@ export class TeamsSyncService {
   private async verifyGithub(
     team: TeamDocument,
     issueKey: string,
-  ): Promise<{ githubStatus: GithubStatus; verifiedAt: Date | null; branchFound: boolean; prFound: boolean }> {
+    expectedAuthorLogin: string | null,
+  ): Promise<{
+    githubStatus: GithubStatus;
+    verifiedAt: Date | null;
+    branchFound: boolean;
+    prFound: boolean;
+    prAuthorLogin: string | null;
+  }> {
     const headers: Record<string, string> = {
       'User-Agent': 'senior-app',
       Accept: 'application/vnd.github+json',
@@ -675,7 +768,7 @@ export class TeamsSyncService {
     );
 
     if (!branchName) {
-      return { githubStatus: GithubStatus.NO_BRANCH, verifiedAt: null, branchFound: false, prFound: false };
+      return { githubStatus: GithubStatus.NO_BRANCH, verifiedAt: null, branchFound: false, prFound: false, prAuthorLogin: null };
     }
 
     // Step 2: find PR for that branch
@@ -687,20 +780,42 @@ export class TeamsSyncService {
     );
 
     if (!pr) {
-      return { githubStatus: GithubStatus.NO_PR, verifiedAt: null, branchFound: true, prFound: false };
+      return { githubStatus: GithubStatus.NO_PR, verifiedAt: null, branchFound: true, prFound: false, prAuthorLogin: null };
     }
 
+    const prAuthorLogin: string | null = pr.user?.login ?? null;
+
     // Step 3: check merge status
-    if (pr.merged_at) {
+    if (!pr.merged_at) {
+      return { githubStatus: GithubStatus.PR_NOT_MERGED, verifiedAt: null, branchFound: true, prFound: true, prAuthorLogin };
+    }
+
+    // Step 4: author check — only verifies when we know the assignee's GitHub
+    // login. Missing assignee or unlinked GitHub account → can't verify, treat
+    // as full verified (we don't downgrade based on missing data, only on real
+    // mismatches), because otherwise students who haven't OAuth-linked GitHub
+    // would block their teammates' completion.
+    if (
+      expectedAuthorLogin &&
+      prAuthorLogin &&
+      expectedAuthorLogin.toLowerCase() !== prAuthorLogin.toLowerCase()
+    ) {
       return {
-        githubStatus: GithubStatus.VERIFIED,
+        githubStatus: GithubStatus.AUTHOR_MISMATCH,
         verifiedAt: new Date(pr.merged_at),
         branchFound: true,
         prFound: true,
+        prAuthorLogin,
       };
     }
 
-    return { githubStatus: GithubStatus.PR_NOT_MERGED, verifiedAt: null, branchFound: true, prFound: true };
+    return {
+      githubStatus: GithubStatus.VERIFIED,
+      verifiedAt: new Date(pr.merged_at),
+      branchFound: true,
+      prFound: true,
+      prAuthorLogin,
+    };
   }
 
   private async findBranchContaining(
@@ -783,8 +898,17 @@ export class TeamsSyncService {
   }
 
   private async buildAccountIdMap(team: TeamDocument): Promise<Map<string, string>> {
+    // User.teamId actually stores the Group.groupId (UUID), not the Team's
+    // mongo _id. Match users by team.groupId. If a team has no groupId yet
+    // (legacy/seeded), fall back to all users with a JIRA accountId so the
+    // mapping degrades gracefully instead of returning everyone as unmapped.
+    const filter: Record<string, unknown> = { jiraAccountId: { $ne: null } };
+    if (team.groupId) {
+      filter.teamId = team.groupId;
+    }
+
     const users = await this.userModel
-      .find({ teamId: team._id?.toString(), jiraAccountId: { $ne: null } })
+      .find(filter)
       .select('_id jiraAccountId')
       .lean()
       .exec();
@@ -792,7 +916,40 @@ export class TeamsSyncService {
     const map = new Map<string, string>();
     for (const u of users) {
       if (u.jiraAccountId) {
-        map.set(u.jiraAccountId, (u._id as any).toString());
+        // Strip any querystring (e.g. "?cloudId=...") that users sometimes
+        // paste from a JIRA profile URL.
+        const cleanId = u.jiraAccountId.split('?')[0].trim();
+        map.set(cleanId, (u._id as any).toString());
+      }
+    }
+
+    this.logger.log(
+      `[sync ${(team._id as any).toString()}] accountId map built: ${map.size} user(s) for groupId=${team.groupId ?? '(none)'}`,
+    );
+    return map;
+  }
+
+  /**
+   * Returns map: studentId → linked GitHub username. Empty entries (students
+   * who never OAuth-linked GitHub) are omitted, so author-check becomes a
+   * "best-effort verify when we have the link" rather than a hard block.
+   */
+  private async buildGithubLoginMap(team: TeamDocument): Promise<Map<string, string>> {
+    const filter: Record<string, unknown> = {
+      githubUsername: { $nin: [null, ''] },
+    };
+    if (team.groupId) filter.teamId = team.groupId;
+
+    const users = await this.userModel
+      .find(filter)
+      .select('_id githubUsername')
+      .lean()
+      .exec();
+
+    const map = new Map<string, string>();
+    for (const u of users) {
+      if (u.githubUsername) {
+        map.set((u._id as any).toString(), u.githubUsername);
       }
     }
     return map;

--- a/backend/src/teams/teams.controller.ts
+++ b/backend/src/teams/teams.controller.ts
@@ -10,11 +10,13 @@ import {
   HttpStatus,
   Query,
   Request,
+  ForbiddenException,
 } from '@nestjs/common';
 import { TeamsService } from './teams.service';
 import { TeamsSyncService } from './teams-sync.service';
 import { TeamLeaderGuard } from './guards/team-leader.guard';
 import { UpdateIntegrationsDto } from './dto/update-integrations.dto';
+import { JiraDiscoverDto } from './dto/jira-discover.dto';
 import { FinalizeSprintDto } from './dto/finalize-sprint.dto';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -31,12 +33,21 @@ export class TeamsController {
   ) {}
 
   @ApiBearerAuth('access-token')
-  @ApiOperation({ summary: 'List teams for dropdown selection (Coordinator, Admin, Professor)' })
+  @ApiOperation({
+    summary:
+      'List teams for dropdown selection (Coordinator/Admin see all; Professor sees only teams of groups they advise)',
+  })
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.Coordinator, Role.Admin, Role.Professor)
   @Get()
   @HttpCode(HttpStatus.OK)
-  async listTeams() {
+  async listTeams(@Request() req: any) {
+    const isProfessor = (req.user?.role ?? '').toLowerCase() === 'professor';
+    if (isProfessor) {
+      const callerId = req.user?.userId ?? req.user?.sub ?? req.user?._id;
+      const advisedGroupIds = await this.teamsService.findGroupIdsAdvisedBy(callerId);
+      return this.teamsService.listAll(advisedGroupIds);
+    }
     return this.teamsService.listAll();
   }
 
@@ -56,6 +67,19 @@ export class TeamsController {
       name: fallbackName,
       groupId,
     });
+  }
+
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary:
+      'Discover JIRA configuration (boards, story points field, accountId) without persisting anything. Used by the wizard to auto-fill the integration form.',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.TeamLeader, Role.Coordinator, Role.Admin)
+  @Post('jira/discover')
+  @HttpCode(HttpStatus.OK)
+  async jiraDiscover(@Body() body: JiraDiscoverDto) {
+    return this.teamsService.discoverJira(body);
   }
 
   @ApiBearerAuth('access-token')
@@ -81,11 +105,33 @@ export class TeamsController {
   }
 
   @ApiBearerAuth('access-token')
-  @ApiOperation({ summary: 'Manually trigger JIRA/GitHub sync for Sprint Stories' })
-  @UseGuards(JwtAuthGuard, TeamLeaderGuard)
+  @ApiOperation({
+    summary:
+      'Manually trigger JIRA/GitHub sync for Sprint Stories (TeamLeader of this team, Coordinator, Admin, or the Professor advising the team)',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.TeamLeader, Role.Coordinator, Role.Admin, Role.Professor)
   @Post(':teamId/sync')
   @HttpCode(HttpStatus.OK)
-  async syncStories(@Param('teamId') teamId: string) {
+  async syncStories(@Param('teamId') teamId: string, @Request() req: any) {
+    const role = (req.user?.role ?? '').toLowerCase();
+    const callerId = req.user?.userId ?? req.user?.sub ?? req.user?._id;
+
+    if (role === 'teamleader') {
+      const team = await this.teamsService.findById(teamId);
+      if (!team || team.leaderId !== callerId) {
+        throw new ForbiddenException('You can only sync your own team.');
+      }
+    } else if (role === 'professor') {
+      const team = await this.teamsService.findById(teamId);
+      const advisedGroupIds = await this.teamsService.findGroupIdsAdvisedBy(callerId);
+      if (!team || !team.groupId || !advisedGroupIds.includes(team.groupId)) {
+        throw new ForbiddenException(
+          'You can only sync teams in groups you advise.',
+        );
+      }
+    }
+
     return this.teamsSyncService.syncStories(teamId);
   }
 
@@ -125,8 +171,20 @@ export class TeamsController {
   @HttpCode(HttpStatus.OK)
   async getAdvisorPanel(
     @Param('teamId') teamId: string,
+    @Request() req: any,
     @Query('groupId') groupId?: string,
   ) {
+    const isProfessor = (req.user?.role ?? '').toLowerCase() === 'professor';
+    if (isProfessor) {
+      const callerId = req.user?.userId ?? req.user?.sub ?? req.user?._id;
+      const team = await this.teamsService.findById(teamId);
+      const advisedGroupIds = await this.teamsService.findGroupIdsAdvisedBy(callerId);
+      if (!team || !team.groupId || !advisedGroupIds.includes(team.groupId)) {
+        throw new ForbiddenException(
+          'You can only view sprint data for teams in groups you advise.',
+        );
+      }
+    }
     return this.teamsSyncService.getAdvisorPanel(teamId, groupId);
   }
 }

--- a/backend/src/teams/teams.module.ts
+++ b/backend/src/teams/teams.module.ts
@@ -11,6 +11,7 @@ import { SprintStory, SprintStorySchema } from './schemas/sprint-story.schema';
 import { User, UserSchema } from '../users/data/user.schema';
 import { SprintConfig, SprintConfigSchema } from '../story-points/schemas/sprint-config.schema';
 import { StoryPointRecord, StoryPointRecordSchema } from '../story-points/schemas/story-point-record.schema';
+import { Group, GroupSchema } from '../groups/group.entity';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { StoryPointRecord, StoryPointRecordSchema } from '../story-points/schema
       { name: User.name, schema: UserSchema },
       { name: SprintConfig.name, schema: SprintConfigSchema },
       { name: StoryPointRecord.name, schema: StoryPointRecordSchema },
+      { name: Group.name, schema: GroupSchema },
     ]),
   ],
   controllers: [TeamsController],

--- a/backend/src/teams/teams.service.ts
+++ b/backend/src/teams/teams.service.ts
@@ -6,13 +6,128 @@ import { lastValueFrom } from 'rxjs';
 import { Team, TeamDocument } from './schemas/team.schema';
 import { UpdateIntegrationsDto } from './dto/update-integrations.dto';
 import { encryptSecret } from '../common/crypto/secret-cipher';
+import { Group, GroupDocument } from '../groups/group.entity';
 
 @Injectable()
 export class TeamsService {
   constructor(
     private readonly httpService: HttpService,
     @InjectModel(Team.name) private teamModel: Model<TeamDocument>,
+    @InjectModel(Group.name) private groupModel: Model<GroupDocument>,
   ) {}
+
+  /**
+   * Discovers JIRA configuration from a domain + email + API token (and
+   * optional project key). Used by the integration wizard to auto-fill the
+   * board id, story-points custom field, and the caller's accountId so the
+   * leader does not have to look these up manually.
+   *
+   * Nothing is persisted here — the caller still submits the regular
+   * /integrations form to save credentials.
+   */
+  async discoverJira(input: {
+    jiraDomain: string;
+    jiraEmail: string;
+    jiraApiToken: string;
+    jiraProjectKey?: string;
+  }): Promise<{
+    accountId: string | null;
+    projects: Array<{ key: string; name: string }>;
+    boards: Array<{ id: string; name: string; type: string }>;
+    storyPointsFieldId: string | null;
+    candidateStoryPointsFields: Array<{ id: string; name: string }>;
+  }> {
+    const { jiraDomain, jiraEmail, jiraApiToken, jiraProjectKey } = input;
+    const auth = Buffer.from(`${jiraEmail}:${jiraApiToken}`).toString('base64');
+    const headers = { Authorization: `Basic ${auth}`, Accept: 'application/json' } as const;
+    const base = `https://${jiraDomain}`;
+
+    const safeData = async <T>(p: Promise<any>, fallback: T): Promise<T> => {
+      try { const r = await p; return (r?.data ?? fallback) as T; } catch { return fallback; }
+    };
+
+    // 1) /myself — validates auth + gives accountId
+    let accountId: string | null = null;
+    try {
+      const res: any = await lastValueFrom(
+        this.httpService.get(`${base}/rest/api/3/myself`, { headers, timeout: 5000 }),
+      );
+      accountId = res.data?.accountId ?? null;
+    } catch (err: any) {
+      throw new HttpException(
+        `JIRA auth failed (${err?.response?.status ?? 'no response'}). Check domain/email/API token.`,
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    // 2) projects (subset of what user can see) — used when project key is unknown
+    const projectsData: any = await safeData(
+      lastValueFrom(this.httpService.get(`${base}/rest/api/3/project/search`, {
+        headers, timeout: 5000, params: { maxResults: 50 },
+      })),
+      { values: [] },
+    );
+    const projects: Array<{ key: string; name: string }> = (projectsData?.values ?? []).map(
+      (p: any) => ({ key: p.key, name: p.name }),
+    );
+
+    // 3) boards for the given project key
+    let boards: Array<{ id: string; name: string; type: string }> = [];
+    if (jiraProjectKey) {
+      const boardsData: any = await safeData(
+        lastValueFrom(this.httpService.get(`${base}/rest/agile/1.0/board`, {
+          headers, timeout: 5000,
+          params: { projectKeyOrId: jiraProjectKey, maxResults: 50 },
+        })),
+        { values: [] },
+      );
+      boards = (boardsData?.values ?? []).map((b: any) => ({
+        id: b.id?.toString(),
+        name: b.name,
+        type: b.type,
+      }));
+    }
+
+    // 4) field directory — find Story Points custom field id
+    const fieldsData: any = await safeData(
+      lastValueFrom(this.httpService.get(`${base}/rest/api/3/field`, { headers, timeout: 5000 })),
+      [],
+    );
+    const allFields: any[] = Array.isArray(fieldsData) ? fieldsData : [];
+    const candidateStoryPointsFields = allFields
+      .filter((f) => /story\s*point/i.test(f.name || ''))
+      .map((f) => ({ id: f.id || f.key, name: f.name }));
+    // Prefer "Story Points" exact match over "Story point estimate"
+    const exact = candidateStoryPointsFields.find((f) => /^story points$/i.test(f.name));
+    const storyPointsFieldId =
+      (exact?.id ?? candidateStoryPointsFields[0]?.id ?? null) || null;
+
+    return {
+      accountId,
+      projects,
+      boards,
+      storyPointsFieldId,
+      candidateStoryPointsFields,
+    };
+  }
+
+  /**
+   * Returns groupIds advised by the given user (matches both legacy
+   * `advisorUserId` and current `assignedAdvisorId` fields).
+   */
+  async findGroupIdsAdvisedBy(advisorUserId: string): Promise<string[]> {
+    const docs = await this.groupModel
+      .find({
+        $or: [
+          { advisorUserId },
+          { assignedAdvisorId: advisorUserId },
+        ],
+      })
+      .select('groupId')
+      .lean()
+      .exec();
+    return docs.map((d) => d.groupId);
+  }
 
   async updateIntegrations(teamId: string, dto: UpdateIntegrationsDto) {
     
@@ -173,11 +288,16 @@ export class TeamsService {
     }
 
     const obj = team.toObject();
+    const groupName = obj.groupId
+      ? (await this.groupModel.findOne({ groupId: obj.groupId }).select('groupName').lean().exec())?.groupName ?? null
+      : null;
+
     return {
       teamId: (team._id as any).toString(),
       name: obj.name,
       leaderId: obj.leaderId,
       groupId: obj.groupId ?? null,
+      groupName,
       jiraProjectKey: obj.jiraProjectKey ?? null,
       jiraDomain: obj.jiraDomain ?? null,
       jiraBoardId: obj.jiraBoardId ?? null,
@@ -190,20 +310,43 @@ export class TeamsService {
   /**
    * Returns a directory of teams suitable for populating UI dropdowns.
    * No secrets (api token, github token) are exposed.
+   *
+   * @param scopeGroupIds  When provided, restricts the result to teams whose
+   *                       groupId is in this set (used for Professor scoping).
    */
-  async listAll() {
+  async listAll(scopeGroupIds?: string[]) {
+    const filter: Record<string, unknown> = {};
+    if (scopeGroupIds) {
+      if (scopeGroupIds.length === 0) return [];
+      filter.groupId = { $in: scopeGroupIds };
+    }
+
     const docs = await this.teamModel
-      .find({})
+      .find(filter)
       .select('_id name leaderId groupId jiraProjectKey jiraDomain jiraBoardId jiraStoryPointsField githubRepositoryId')
       .sort({ name: 1 })
       .lean()
       .exec();
+
+    // Resolve groupId → groupName in one query (no N+1).
+    const groupIds = Array.from(
+      new Set(docs.map((t) => t.groupId).filter((g): g is string => !!g)),
+    );
+    const groups = groupIds.length
+      ? await this.groupModel
+          .find({ groupId: { $in: groupIds } })
+          .select('groupId groupName')
+          .lean()
+          .exec()
+      : [];
+    const nameByGroupId = new Map(groups.map((g) => [g.groupId, g.groupName]));
 
     return docs.map((t) => ({
       teamId: (t._id as any).toString(),
       name: t.name,
       leaderId: t.leaderId,
       groupId: t.groupId ?? null,
+      groupName: t.groupId ? nameByGroupId.get(t.groupId) ?? null : null,
       jiraProjectKey: t.jiraProjectKey ?? null,
       jiraDomain: t.jiraDomain ?? null,
       jiraBoardId: t.jiraBoardId ?? null,

--- a/backend/src/users/dto/set-jira-account.dto.ts
+++ b/backend/src/users/dto/set-jira-account.dto.ts
@@ -9,6 +9,10 @@ export class SetJiraAccountDto {
   })
   @IsOptional()
   @IsString()
-  @Transform(({ value }) => value?.trim() ?? '')
+  @Transform(({ value }) => {
+    if (value === null || value === undefined) return '';
+    // Strip ?cloudId=... or any querystring users sometimes paste from URL.
+    return String(value).split('?')[0].trim();
+  })
   jiraAccountId!: string;
 }

--- a/frontend/src/components/TeamIntegrationsForm.jsx
+++ b/frontend/src/components/TeamIntegrationsForm.jsx
@@ -16,15 +16,74 @@ const FIELDS = [
 
 const EMPTY = FIELDS.reduce((acc, f) => ({ ...acc, [f.key]: '' }), {});
 
-const TeamIntegrationsForm = ({ team, groups = [] }) => {
+const TeamIntegrationsForm = ({ team }) => {
   const [values, setValues] = useState(EMPTY);
   const [status, setStatus] = useState({ saving: false, error: null, info: null });
+  const [discovery, setDiscovery] = useState({
+    busy: false,
+    error: null,
+    info: null,
+    boards: null,        // null = not yet run; [] = ran but empty
+    projects: null,
+  });
 
-  const groupForTeam = team?.groupId
-    ? groups.find((g) => g.groupId === team.groupId) || null
-    : null;
+  const groupName = team?.groupName || null;
 
   const update = (k) => (e) => setValues((v) => ({ ...v, [k]: e.target.value }));
+
+  const handleDiscover = async () => {
+    if (!values.jiraDomain || !values.jiraEmail || !values.jiraApiToken) {
+      setDiscovery((d) => ({ ...d, error: 'Fill JIRA Domain, Email and API Token first.' }));
+      return;
+    }
+    setDiscovery({ busy: true, error: null, info: null, boards: null, projects: null });
+    try {
+      const res = await apiClient.post(apiConfig.endpoints.teamJiraDiscover, {
+        jiraDomain: values.jiraDomain,
+        jiraEmail: values.jiraEmail,
+        jiraApiToken: values.jiraApiToken,
+        jiraProjectKey: values.jiraProjectKey || undefined,
+      });
+      const d = res.data || {};
+      const next = { ...values };
+      let info = [];
+
+      if (d.storyPointsFieldId && !next.jiraStoryPointsField) {
+        next.jiraStoryPointsField = d.storyPointsFieldId;
+        info.push(`story points field → ${d.storyPointsFieldId}`);
+      }
+
+      const boards = Array.isArray(d.boards) ? d.boards : [];
+      if (boards.length === 1 && !next.jiraBoardId) {
+        next.jiraBoardId = boards[0].id;
+        info.push(`board → ${boards[0].name} (id ${boards[0].id})`);
+      }
+
+      // Auto-pick project key when there's only one and the user hasn't chosen
+      const projects = Array.isArray(d.projects) ? d.projects : [];
+      if (!next.jiraProjectKey && projects.length === 1) {
+        next.jiraProjectKey = projects[0].key;
+        info.push(`project → ${projects[0].name} (${projects[0].key})`);
+      }
+
+      setValues(next);
+      setDiscovery({
+        busy: false,
+        error: null,
+        info: info.length ? `Auto-filled: ${info.join(', ')}.` : 'Connection OK.',
+        boards,
+        projects,
+      });
+    } catch (err) {
+      setDiscovery({
+        busy: false,
+        error: err?.response?.data?.message || 'Discover failed. Check credentials.',
+        info: null,
+        boards: null,
+        projects: null,
+      });
+    }
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -57,8 +116,8 @@ const TeamIntegrationsForm = ({ team, groups = [] }) => {
       {/* Group readonly chip — leader cannot change this */}
       <div style={styles.groupChip}>
         <span style={styles.groupLabel}>Group</span>
-        {groupForTeam ? (
-          <span style={styles.groupValue}>{groupForTeam.groupName}</span>
+        {groupName ? (
+          <span style={styles.groupValue}>{groupName}</span>
         ) : team?.groupId ? (
           <span style={styles.groupValueDim}>{team.groupId}</span>
         ) : (
@@ -72,22 +131,94 @@ const TeamIntegrationsForm = ({ team, groups = [] }) => {
       {status.info && <div style={styles.infoBox}>{status.info}</div>}
 
       <form onSubmit={handleSubmit}>
-        {FIELDS.map((f) => (
-          <div key={f.key} style={{ marginBottom: 10 }}>
-            <label style={styles.label}>
-              {f.label}{f.required ? ' *' : ''}
-            </label>
+        {/* Step 1 — credentials needed for the discover call */}
+        {['jiraDomain', 'jiraEmail', 'jiraApiToken', 'jiraProjectKey'].map((key) => {
+          const f = FIELDS.find((x) => x.key === key);
+          return (
+            <div key={key} style={{ marginBottom: 10 }}>
+              <label style={styles.label}>{f.label}{f.required ? ' *' : ''}</label>
+              <input
+                type={f.type || 'text'}
+                value={values[key]}
+                onChange={update(key)}
+                placeholder={f.placeholder}
+                required={f.required}
+                style={styles.input}
+                autoComplete="off"
+              />
+            </div>
+          );
+        })}
+
+        <button
+          type="button"
+          onClick={handleDiscover}
+          disabled={discovery.busy}
+          style={styles.discoverBtn}
+        >
+          {discovery.busy ? 'Discovering…' : 'Discover from JIRA (auto-fill board + field)'}
+        </button>
+        {discovery.error && <div style={{ ...styles.errorBox, marginTop: 8 }}>{discovery.error}</div>}
+        {discovery.info && <div style={{ ...styles.infoBox, marginTop: 8 }}>{discovery.info}</div>}
+
+        {/* Board: dropdown when discovery returned options, plain input otherwise */}
+        <div style={{ marginBottom: 10, marginTop: 12 }}>
+          <label style={styles.label}>JIRA Board</label>
+          {Array.isArray(discovery.boards) && discovery.boards.length > 0 ? (
+            <select
+              value={values.jiraBoardId}
+              onChange={update('jiraBoardId')}
+              style={{ ...styles.input, fontFamily: 'inherit' }}
+            >
+              <option value="">— Select a board —</option>
+              {discovery.boards.map((b) => (
+                <option key={b.id} value={b.id}>{b.name} ({b.type}, id {b.id})</option>
+              ))}
+            </select>
+          ) : (
             <input
-              type={f.type || 'text'}
-              value={values[f.key]}
-              onChange={update(f.key)}
-              placeholder={f.placeholder}
-              required={f.required}
+              type="text"
+              value={values.jiraBoardId}
+              onChange={update('jiraBoardId')}
+              placeholder="42 (or click Discover above)"
               style={styles.input}
               autoComplete="off"
             />
-          </div>
-        ))}
+          )}
+        </div>
+
+        <div style={{ marginBottom: 10 }}>
+          <label style={styles.label}>Story Points Custom Field</label>
+          <input
+            type="text"
+            value={values.jiraStoryPointsField}
+            onChange={update('jiraStoryPointsField')}
+            placeholder="customfield_10016 (or click Discover above)"
+            style={styles.input}
+            autoComplete="off"
+          />
+        </div>
+
+        {/* GitHub block */}
+        <div style={{ height: 1, background: '#1e293b', margin: '16px 0' }} />
+
+        {['githubRepositoryId', 'githubToken'].map((key) => {
+          const f = FIELDS.find((x) => x.key === key);
+          return (
+            <div key={key} style={{ marginBottom: 10 }}>
+              <label style={styles.label}>{f.label}{f.required ? ' *' : ''}</label>
+              <input
+                type={f.type || 'text'}
+                value={values[key]}
+                onChange={update(key)}
+                placeholder={f.placeholder}
+                required={f.required}
+                style={styles.input}
+                autoComplete="off"
+              />
+            </div>
+          );
+        })}
 
         <button type="submit" disabled={status.saving} style={styles.primaryBtn}>
           {status.saving ? 'Saving…' : 'Validate & Save'}
@@ -102,8 +233,8 @@ TeamIntegrationsForm.propTypes = {
     teamId: PropTypes.string.isRequired,
     name: PropTypes.string,
     groupId: PropTypes.string,
+    groupName: PropTypes.string,
   }).isRequired,
-  groups: PropTypes.array,
 };
 
 const styles = {
@@ -145,6 +276,11 @@ const styles = {
     width: '100%', padding: '10px 16px', backgroundColor: '#111827',
     color: '#f8fafc', border: '1px solid #374151', borderRadius: 8,
     fontWeight: 600, cursor: 'pointer',
+  },
+  discoverBtn: {
+    width: '100%', padding: '9px 16px', backgroundColor: '#1d4ed8',
+    color: '#f8fafc', border: '1px solid #1e40af', borderRadius: 8,
+    fontWeight: 600, cursor: 'pointer', marginTop: 4,
   },
 };
 

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -92,6 +92,7 @@ export const apiConfig = {
     teamIntegrationsStatus: (teamId) => `/teams/${teamId}/integrations/status`,
     teamsList: '/teams',
     teamMine: '/teams/mine',
+    teamJiraDiscover: '/teams/jira/discover',
     teamStoryPoints: (teamId) => `/teams/${teamId}/story-points`,
   },
 };

--- a/frontend/src/pages/AdvisorSprintPanel.jsx
+++ b/frontend/src/pages/AdvisorSprintPanel.jsx
@@ -7,6 +7,7 @@ const GITHUB_STATUS_LABEL = {
   no_branch: { label: 'No Branch', color: '#94a3b8' },
   no_pr: { label: 'No PR', color: '#f59e0b' },
   pr_not_merged: { label: 'PR Open', color: '#3b82f6' },
+  author_mismatch: { label: 'Author Mismatch', color: '#a855f7' },
   verified: { label: 'Verified ✓', color: '#22c55e' },
 };
 
@@ -170,7 +171,7 @@ function AdvisorSprintPanel() {
   }, [selectedTeam, groups]);
 
   const load = async (e) => {
-    e.preventDefault();
+    if (e?.preventDefault) e.preventDefault();
     if (!selectedTeam) return;
     setData(null);
     setStatus({ loading: true, error: '' });
@@ -184,6 +185,18 @@ function AdvisorSprintPanel() {
       setStatus({ loading: false, error: '' });
     } catch (err) {
       const msg = err.response?.data?.message ?? 'Failed to load sprint data.';
+      setStatus({ loading: false, error: msg });
+    }
+  };
+
+  const runSync = async () => {
+    if (!selectedTeam) return;
+    setStatus({ loading: true, error: '' });
+    try {
+      await apiClient.post(apiConfig.endpoints.teamSync(selectedTeam.teamId));
+      await load();
+    } catch (err) {
+      const msg = err.response?.data?.message ?? 'Failed to run sync.';
       setStatus({ loading: false, error: msg });
     }
   };
@@ -243,6 +256,21 @@ function AdvisorSprintPanel() {
           }}
         >
           {status.loading ? 'Loading…' : 'Load Panel'}
+        </button>
+        <button
+          type="button"
+          onClick={runSync}
+          disabled={status.loading || !teamId}
+          style={{
+            padding: '10px 20px', borderRadius: '6px', background: '#0f172a',
+            color: '#e2e8f0', fontWeight: 700,
+            border: '1px solid #334155',
+            cursor: status.loading || !teamId ? 'not-allowed' : 'pointer',
+            opacity: status.loading || !teamId ? 0.6 : 1,
+          }}
+          title="Trigger an immediate JIRA + GitHub sync for this team"
+        >
+          Run Sync Now
         </button>
       </form>
 

--- a/frontend/src/pages/IntegrationsPage.jsx
+++ b/frontend/src/pages/IntegrationsPage.jsx
@@ -13,7 +13,6 @@ const IntegrationsPage = () => {
   const [loadError, setLoadError] = useState(null);
 
   const [myTeam, setMyTeam] = useState(null);
-  const [groups, setGroups] = useState([]);
   const [myTeamError, setMyTeamError] = useState('');
 
   useEffect(() => {
@@ -37,28 +36,18 @@ const IntegrationsPage = () => {
     let cancelled = false;
     (async () => {
       try {
-        const [mineRes, groupsRes] = await Promise.all([
-          apiClient.get(apiConfig.endpoints.teamMine).catch((err) => {
-            if (cancelled) return null;
-            const status = err?.response?.status;
-            if (status === 401 || status === 403) {
-              setMyTeamError(
-                'Only Team Leaders can configure team integrations. Create a team first.',
-              );
-            } else {
-              setMyTeamError(err?.response?.data?.message || 'Failed to load your team.');
-            }
-            return null;
-          }),
-          apiClient.get(apiConfig.endpoints.groups, { params: { page: 1, limit: 100 } })
-            .catch(() => ({ data: { data: [] } })),
-        ]);
+        const mineRes = await apiClient.get(apiConfig.endpoints.teamMine);
         if (cancelled) return;
-        setMyTeam(mineRes?.data ?? null);
-        setGroups(groupsRes.data?.data ?? groupsRes.data ?? []);
+        setMyTeam(mineRes.data ?? null);
       } catch (err) {
-        if (!cancelled) {
-          setMyTeamError(err?.response?.data?.message || 'Failed to load team data.');
+        if (cancelled) return;
+        const status = err?.response?.status;
+        if (status === 401 || status === 403) {
+          setMyTeamError(
+            'Only Team Leaders can configure team integrations. Create a team first.',
+          );
+        } else {
+          setMyTeamError(err?.response?.data?.message || 'Failed to load your team.');
         }
       }
     })();
@@ -105,7 +94,7 @@ const IntegrationsPage = () => {
               {myTeam ? (
                 <>
                   <IntegrationStatusCard teamId={myTeam.teamId} />
-                  <TeamIntegrationsForm team={myTeam} groups={groups} />
+                  <TeamIntegrationsForm team={myTeam} />
                 </>
               ) : !myTeamError ? (
                 <div style={{


### PR DESCRIPTION
## Summary
This PR adds a JIRA discovery flow for team integrations, expands visibility rules so professors, team members, and coordinators see the right teams/groups, and tightens sprint sync with PR-author mismatch detection. It also updates the frontend to expose the new discovery action, surface the new sync path, and show the new `author_mismatch` sprint status.


---

## Type of Change
<!-- Check all that apply -->
- [x] Feature (new endpoint or business logic)
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Configuration / infrastructure
- [x] Background job / scheduled task
- [x] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change
<!-- List the files, modules, or layers touched. Be specific. -->

**Backend:**
- Controller(s): backend/src/teams/teams.controller.ts, backend/src/groups/groups.controller.ts
- Use case(s) / service(s): backend/src/teams/teams.service.ts, backend/src/teams/teams-sync.service.ts, backend/src/teams/teams-cron.service.ts, backend/src/groups/groups.service.ts, backend/src/auth/guards/roles.guard.ts
- Repository / DB layer: Mongoose-backed lookups in backend/src/teams/teams-sync.service.ts and backend/src/groups/groups.service.ts
- Schema / migration: backend/src/teams/schemas/sprint-story.schema.ts
- OpenAPI spec file(s): none updated in this branch

**Frontend:** (if applicable)
- Component(s): frontend/src/components/TeamIntegrationsForm.jsx, frontend/src/pages/AdvisorSprintPanel.jsx, frontend/src/pages/IntegrationsPage.jsx
- API client / DTO: frontend/src/config/api.js

**Infrastructure / Config:** (if applicable)
- Backend boot-time sync scheduling in backend/src/teams/teams-cron.service.ts

---

## API Contract Alignment
<!-- Only fill in if this PR touches an endpoint -->

| Field | Value |
|---|---|
| Endpoint | Multiple endpoints: `GET /teams`, `GET /groups`, `POST /teams/jira/discover`, `POST /teams/:teamId/sync`, `GET /teams/:teamId/advisor-panel` |
| OperationId | `listTeams`, `listGroups`, `jiraDiscover`, `syncStories`, `getAdvisorPanel` |
| OpenAPI file | process5.yaml |
| Spec updated in this PR | No |

- [ ] Response shape matches OpenAPI schema exactly
- [ ] All documented status codes are reachable via implementation
- [ ] No fields added to response that are not in the spec
- [x] groupId / actorId extracted from JWT — NOT from request body (if applicable)

---

## Clean Architecture Checklist
<!-- Verify the layer boundaries defined in the issue acceptance criteria -->

**Infrastructure / API layer:**
- [ ] Auth guard behavior matches status code matrix in issue
- [ ] Controller returns contract-compliant response shape
- [x] Input validation rules enforced (required fields, UUID format, enum values)

**Application / Use Case layer:**
- [ ] Use case orchestrates all validations before any DB write
- [ ] Sensitive fields never exposed in response DTOs
- [ ] Error mapping is deterministic — same input always produces same error code

**Domain / Repository layer:**
- [ ] Repository queries enforce correct domain filters (role scoping, ownership)
- [ ] Concurrency / uniqueness constraints protected at DB level, not only application level
- [ ] All DB failures caught and mapped to generic 500 — no raw DB errors reach the client

---

## Test Evidence
<!-- Fill in what was tested. Link to test files where possible. -->

**Unit tests:**
- [ ] Happy path covered
- [ ] All business-rule failure cases covered (see Section 11 of issue)
- [ ] Repository failure mapping tested

**Controller tests:**
- [ ] 401 unauthorized (missing/invalid JWT)
- [ ] 403 forbidden (wrong role or ownership mismatch)
- [ ] Success response shape and status code
- [ ] Validation error response (400)

**Integration / E2E tests:**
- [ ] Happy flow end-to-end
- [ ] Conflict / locked / not-found flow end-to-end
- [ ] Contract parity with OpenAPI verified

**Test file locations:**
- Unit: N/A
- Controller: N/A
- E2E: N/A

**Test run output:**
Not run. This draft was prepared by comparing the branch diff against `main`.

---

## Status Code Matrix Verification
<!-- Confirm every documented status code is reachable -->

| Code | Scenario | Tested |
|---|---|---|
| 2xx | Happy path | ☐ |
| 400 | Validation failure | ☐ |
| 401 | Missing/invalid JWT | ☐ |
| 403 | Role or ownership mismatch | ☐ |
| 422 | JIRA auth failure during discovery | ☐ |
| 500 | DB/internal failure | ☐ |

<!-- Remove rows not applicable to this PR -->

---

## Observability Checklist
<!-- From Section 12 of issue -->
- [ ] Key business event is logged with correlationId / requestId
- [ ] No secrets, tokens, hashes, or sensitive personal data in logs
- [ ] 500 responses include actionable internal context in server logs
- [ ] Audit log entry written (if this is a POST, PATCH, or DELETE operation — requires Issue 47 to be merged first)

---

## Migration / Breaking Change Assessment
- [x] No database migration required
- [ ] Migration included and tested with rollback plan
- [x] No breaking change to API contract
- [ ] Breaking change — existing consumers notified: [describe]
- [x] Backward compatibility note: Existing flows continue to work; the new discovery endpoint is additive.

---

## Out of Scope Confirmation
<!-- From Section 14 of issue — confirm these were NOT implemented -->
The following are explicitly out of scope for this PR and were not implemented:
- OpenAPI regeneration / spec file updates
- Dedicated automated test additions in this branch
- Full JIRA OAuth flow beyond the basic discover call

---

## Dependencies
<!-- List any PRs, issues, or external changes this PR depends on -->
- Blocked by: #N/A
- Must be merged before: #N/A
- Requires Issue 47 (Audit logging) to be merged first: No

---

## Reviewer Notes
- Sync and get story points tested via Jira and Github repository manually and ensured its working yet feature is not completed as a whole. Ui is still lack of the story point section view per student and a universal page for professors to view each students contribution.
- Professor-scoped access now filters both team lists and sprint-panel sync actions by the groups they advise.
- Sprint sync now records the merged PR author and marks mismatches as `author_mismatch` instead of treating them as verified.
- The integrations form now uses the discover endpoint to auto-fill the board and story-points field when possible.

---