### PR TITLE
Fix/fullstack/jira GitHub integration

### DIFF
--- a/backend/src/teams/guards/team-leader.guard.ts
+++ b/backend/src/teams/guards/team-leader.guard.ts
@@ -24,7 +24,14 @@ export class TeamLeaderGuard implements CanActivate {
       );
     }
 
-    const team = await this.teamModel.findById(teamId);
+    // Accept either Mongo _id or groupId UUID in the URL.
+    let team = null as any;
+    if (/^[0-9a-fA-F]{24}$/.test(teamId)) {
+      team = await this.teamModel.findById(teamId);
+    }
+    if (!team) {
+      team = await this.teamModel.findOne({ groupId: teamId });
+    }
     if (!team) {
       throw new NotFoundException('Team not found.');
     }

--- a/backend/src/teams/teams-sync.service.ts
+++ b/backend/src/teams/teams-sync.service.ts
@@ -62,6 +62,20 @@ export class TeamsSyncService {
     private readonly httpService: HttpService,
   ) {}
 
+  /**
+   * Accepts either a Mongo ObjectId string or a groupId UUID and returns the
+   * matching Team. Sync URLs use groupId UUIDs while the cron passes the
+   * Team document's own _id — both must work.
+   */
+  private async resolveTeam(idOrGroupId: string): Promise<TeamDocument | null> {
+    if (!idOrGroupId) return null;
+    if (/^[0-9a-fA-F]{24}$/.test(idOrGroupId)) {
+      const byId = await this.teamModel.findById(idOrGroupId).exec();
+      if (byId) return byId;
+    }
+    return this.teamModel.findOne({ groupId: idOrGroupId }).exec();
+  }
+
   // ─────────────────────────────────────────────────────────
   // PUBLIC: Integration health / validation status
   // ─────────────────────────────────────────────────────────
@@ -72,7 +86,7 @@ export class TeamsSyncService {
    * returned — only configuration metadata and probe results.
    */
   async getIntegrationStatus(teamId: string) {
-    const team = await this.teamModel.findById(teamId).exec();
+    const team = await this.resolveTeam(teamId);
     if (!team) throw new NotFoundException(`Team ${teamId} not found.`);
 
     const jiraConfigured = !!(
@@ -262,7 +276,7 @@ export class TeamsSyncService {
   // ─────────────────────────────────────────────────────────
 
   async syncStories(teamId: string) {
-    const team = await this.teamModel.findById(teamId).exec();
+    const team = await this.resolveTeam(teamId);
     if (!team) throw new NotFoundException(`Team ${teamId} not found.`);
 
     if (!team.jiraDomain || !team.jiraApiToken || !team.jiraProjectKey || !team.jiraEmail) {
@@ -437,7 +451,7 @@ export class TeamsSyncService {
     lockedCount: number;
     studentRecords: { studentId: string; completedPoints: number; targetPoints: number }[];
   }> {
-    const team = await this.teamModel.findById(teamId).exec();
+    const team = await this.resolveTeam(teamId);
     if (!team) throw new NotFoundException(`Team ${teamId} not found.`);
 
     const sprintConfig = await this.sprintConfigModel.findOne({ groupId, sprintId }).exec();
@@ -505,7 +519,7 @@ export class TeamsSyncService {
   // ─────────────────────────────────────────────────────────
 
   async getLatestSync(teamId: string) {
-    const team = await this.teamModel.findById(teamId).exec();
+    const team = await this.resolveTeam(teamId);
     if (!team) throw new NotFoundException(`Team ${teamId} not found.`);
 
     return this.sprintStoryModel
@@ -517,11 +531,33 @@ export class TeamsSyncService {
   }
 
   // ─────────────────────────────────────────────────────────
+  // PUBLIC: Story points summary (completed vs total)
+  // ─────────────────────────────────────────────────────────
+
+  async getStoryPointsSummary(teamId: string): Promise<{ completedStoryPoints: number; totalStoryPoints: number }> {
+    const team = await this.resolveTeam(teamId);
+    if (!team) throw new NotFoundException(`Team ${teamId} not found.`);
+
+    const stories = await this.sprintStoryModel
+      .find({ teamId })
+      .select('work isComplete -_id')
+      .lean()
+      .exec();
+
+    const totalStoryPoints = stories.reduce((sum, s) => sum + (s.work ?? 0), 0);
+    const completedStoryPoints = stories
+      .filter((s) => s.isComplete)
+      .reduce((sum, s) => sum + (s.work ?? 0), 0);
+
+    return { completedStoryPoints, totalStoryPoints };
+  }
+
+  // ─────────────────────────────────────────────────────────
   // PUBLIC: Advisor panel aggregation
   // ─────────────────────────────────────────────────────────
 
   async getAdvisorPanel(teamId: string, groupId?: string): Promise<AdvisorPanelResult> {
-    const team = await this.teamModel.findById(teamId).exec();
+    const team = await this.resolveTeam(teamId);
     if (!team) throw new NotFoundException(`Team ${teamId} not found.`);
 
     const stories = await this.sprintStoryModel

--- a/backend/src/teams/teams.controller.ts
+++ b/backend/src/teams/teams.controller.ts
@@ -118,12 +118,12 @@ export class TeamsController {
     const callerId = req.user?.userId ?? req.user?.sub ?? req.user?._id;
 
     if (role === 'teamleader') {
-      const team = await this.teamsService.findById(teamId);
+      const team = await this.teamsService.findByIdOrGroupId(teamId);
       if (!team || team.leaderId !== callerId) {
         throw new ForbiddenException('You can only sync your own team.');
       }
     } else if (role === 'professor') {
-      const team = await this.teamsService.findById(teamId);
+      const team = await this.teamsService.findByIdOrGroupId(teamId);
       const advisedGroupIds = await this.teamsService.findGroupIdsAdvisedBy(callerId);
       if (!team || !team.groupId || !advisedGroupIds.includes(team.groupId)) {
         throw new ForbiddenException(
@@ -177,7 +177,7 @@ export class TeamsController {
     const isProfessor = (req.user?.role ?? '').toLowerCase() === 'professor';
     if (isProfessor) {
       const callerId = req.user?.userId ?? req.user?.sub ?? req.user?._id;
-      const team = await this.teamsService.findById(teamId);
+      const team = await this.teamsService.findByIdOrGroupId(teamId);
       const advisedGroupIds = await this.teamsService.findGroupIdsAdvisedBy(callerId);
       if (!team || !team.groupId || !advisedGroupIds.includes(team.groupId)) {
         throw new ForbiddenException(

--- a/backend/src/teams/teams.service.ts
+++ b/backend/src/teams/teams.service.ts
@@ -222,16 +222,19 @@ export class TeamsService {
       // own group at /groups/my-team). The leader cannot reassign their team
       // to a different group through this endpoint — only fill in if the
       // existing team has no group yet (legacy/seeded teams).
-      if (groupId) {
-        const existing = await this.teamModel.findById(teamId).select('groupId').lean().exec();
-        if (existing && !existing.groupId) {
-          updateFields.groupId = groupId;
-        }
+      // Resolve the target team — `teamId` may be a Mongo _id or a groupId UUID.
+      const target = await this.findByIdOrGroupId(teamId);
+      if (!target) {
+        throw new HttpException('Team not found.', HttpStatus.NOT_FOUND);
+      }
+
+      if (groupId && !target.groupId) {
+        updateFields.groupId = groupId;
       }
 
       updatedTeam = await this.teamModel
         .findByIdAndUpdate(
-          teamId,
+          (target._id as any),
           updateFields,
           { returnDocument: 'after' },
         )
@@ -264,6 +267,21 @@ export class TeamsService {
 
   findById(id: string) {
     return this.teamModel.findById(id).exec();
+  }
+
+  /**
+   * Resolves a team by either its Mongo ObjectId or its groupId UUID. Routes
+   * pass `:teamId` interchangeably (the integrations / sync chain standardised
+   * on groupId UUIDs in URLs); this helper accepts both so older callers and
+   * direct ObjectId access keep working.
+   */
+  async findByIdOrGroupId(idOrGroupId: string) {
+    if (!idOrGroupId) return null;
+    if (/^[0-9a-fA-F]{24}$/.test(idOrGroupId)) {
+      const byId = await this.teamModel.findById(idOrGroupId).exec();
+      if (byId) return byId;
+    }
+    return this.teamModel.findOne({ groupId: idOrGroupId }).exec();
   }
 
   /**

--- a/frontend/src/pages/IntegrationsPage.jsx
+++ b/frontend/src/pages/IntegrationsPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link2, AlertCircle, Loader2, Lock, ShieldCheck, Kanban } from 'lucide-react';
+import { Link2, AlertCircle, Loader2, Lock, ShieldCheck } from 'lucide-react';
 import authService from '../utils/authService';
 import apiClient from '../utils/apiClient';
 import apiConfig from '../config/api';
@@ -9,6 +9,7 @@ import TeamIntegrationsForm from '../components/TeamIntegrationsForm';
 import IntegrationStatusCard from '../components/IntegrationStatusCard';
 import { PageHeader } from '../components/ui';
 
+// eslint-disable-next-line no-unused-vars
 function IntegrationCard({ icon: Icon, name, description, comingSoon }) {
   return (
     <div className="relative flex items-start gap-3.5 overflow-hidden rounded-2xl border border-[#1f1f23] bg-[#131316] p-5">
@@ -79,76 +80,6 @@ const IntegrationsPage = () => {
     return () => { cancelled = true; };
   }, [userId]);
 
-  const renderIntegrationsContent = () => {
-    if (loading) {
-      return (
-        <div className="flex h-44 items-center justify-center gap-2 rounded-2xl border border-[#1f1f23] bg-[#131316] text-[13px] text-zinc-500">
-          <Loader2 size={14} className="animate-spin" /> Loading account...
-        </div>
-      );
-    }
-
-    if (loadError) {
-      return (
-        <div className="rounded-2xl border border-rose-900/40 bg-rose-950/20 p-4 text-[13px] text-rose-300">
-          <div className="flex items-start gap-2">
-            <AlertCircle size={14} className="mt-0.5 shrink-0" />
-            <span>{loadError}</span>
-          </div>
-        </div>
-      );
-    }
-
-    if (!userId) {
-      return (
-        <div className="flex h-44 items-center justify-center rounded-2xl border border-[#1f1f23] bg-[#131316] text-[13px] text-zinc-500">
-          Sign in required
-        </div>
-      );
-    }
-
-    return (
-      <>
-        <GithubConnect userId={userId} />
-        <JiraConnect userId={userId} />
-
-        <div style={{ marginTop: 24 }}>
-          <h3 style={{ color: '#e2e8f0', fontSize: 16, fontWeight: 600 }}>
-            Team Integrations
-          </h3>
-          <p style={{ color: '#94a3b8', fontSize: 13, marginTop: 4 }}>
-            Connect your team&apos;s JIRA and GitHub. You can only configure your own team.
-          </p>
-
-          {myTeamError && (
-            <div style={{
-              marginTop: 12,
-              padding: 10,
-              borderRadius: 8,
-              background: '#450a0a',
-              border: '1px solid #7f1d1d',
-              color: '#fca5a5',
-              fontSize: 13,
-            }}>
-              {myTeamError}
-            </div>
-          )}
-
-          {myTeam ? (
-            <>
-              <IntegrationStatusCard teamId={myTeam.teamId} />
-              <TeamIntegrationsForm team={myTeam} groups={groups} />
-            </>
-          ) : !myTeamError ? (
-            <div style={{ marginTop: 12, color: '#94a3b8', fontSize: 13 }}>
-              Loading your team...
-            </div>
-          ) : null}
-        </div>
-      </>
-    );
-  };
-
   return (
     <div>
       <PageHeader
@@ -158,38 +89,77 @@ const IntegrationsPage = () => {
       />
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        {/* Active integrations — main column */}
-        <div className="space-y-4 lg:col-span-2">
-          <div className="flex items-center justify-between">
-            <h2 className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
-              Available
-            </h2>
-            <span className="text-[11px] text-zinc-700">1 active</span>
+        {/* Main column: account-level + team-level integrations */}
+        <div className="space-y-6 lg:col-span-2">
+          <div>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                Personal
+              </h2>
+              <span className="text-[11px] text-zinc-700">Per user</span>
+            </div>
+
+            {loadError && (
+              <div className="mb-3 flex items-start gap-2 rounded-xl border border-rose-900/40 bg-rose-950/20 p-3.5 text-[13px] text-rose-300">
+                <AlertCircle size={14} className="mt-px shrink-0" />
+                <span>{loadError}</span>
+              </div>
+            )}
+
+            {loading ? (
+              <div className="flex h-44 items-center justify-center gap-2 rounded-2xl border border-[#1f1f23] bg-[#131316] text-[13px] text-zinc-500">
+                <Loader2 size={14} className="animate-spin" /> Loading account…
+              </div>
+            ) : userId ? (
+              <div className="space-y-4">
+                <GithubConnect userId={userId} />
+                <JiraConnect userId={userId} />
+              </div>
+            ) : (
+              !loadError && (
+                <div className="flex h-44 items-center justify-center rounded-2xl border border-[#1f1f23] bg-[#131316] text-[13px] text-zinc-500">
+                  Sign in required
+                </div>
+              )
+            )}
           </div>
 
-          {loadError && (
-            <div className="flex items-start gap-2 rounded-xl border border-rose-900/40 bg-rose-950/20 p-3.5 text-[13px] text-rose-300">
-              <AlertCircle size={14} className="mt-px shrink-0" />
-              <span>{loadError}</span>
-            </div>
-          )}
-
-          {loading ? (
-            <div className="flex h-44 items-center justify-center gap-2 rounded-2xl border border-[#1f1f23] bg-[#131316] text-[13px] text-zinc-500">
-              <Loader2 size={14} className="animate-spin" /> Loading account…
-            </div>
-          ) : userId ? (
-            <GithubConnect userId={userId} />
-          ) : (
-            !loadError && (
-              <div className="flex h-44 items-center justify-center rounded-2xl border border-[#1f1f23] bg-[#131316] text-[13px] text-zinc-500">
-                Sign in required
+          {/* Team Integrations */}
+          {userId && (
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                  Team Integrations
+                </h2>
+                <span className="text-[11px] text-zinc-700">Team Leader only</span>
               </div>
-            )
+
+              <p className="mb-3 text-[13px] text-zinc-500">
+                Connect your team&apos;s JIRA &amp; GitHub. You can only configure your own team.
+              </p>
+
+              {myTeamError && (
+                <div className="mb-3 flex items-start gap-2 rounded-xl border border-rose-900/40 bg-rose-950/20 p-3.5 text-[13px] text-rose-300">
+                  <AlertCircle size={14} className="mt-px shrink-0" />
+                  <span>{myTeamError}</span>
+                </div>
+              )}
+
+              {myTeam ? (
+                <div className="space-y-4">
+                  <IntegrationStatusCard teamId={myTeam.teamId} />
+                  <TeamIntegrationsForm team={myTeam} />
+                </div>
+              ) : !myTeamError ? (
+                <div className="flex h-44 items-center justify-center gap-2 rounded-2xl border border-[#1f1f23] bg-[#131316] text-[13px] text-zinc-500">
+                  <Loader2 size={14} className="animate-spin" /> Loading your team…
+                </div>
+              ) : null}
+            </div>
           )}
 
           {/* Roadmap */}
-          <div className="mt-8">
+          <div>
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                 Coming soon
@@ -197,12 +167,6 @@ const IntegrationsPage = () => {
               <span className="text-[11px] text-zinc-700">Planned</span>
             </div>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <IntegrationCard
-                icon={Kanban}
-                name="Jira"
-                description="Pull sprint progress and story points directly from Jira boards."
-                comingSoon
-              />
               <IntegrationCard
                 icon={ShieldCheck}
                 name="Single Sign-On"
@@ -212,48 +176,9 @@ const IntegrationsPage = () => {
             </div>
           </div>
         </div>
-      <aside>
-      <div className="max-w-lg">
-        {userId ? (
-          <>
-            <GithubConnect userId={userId} />
-            <JiraConnect userId={userId} />
 
-            <div style={{ marginTop: 24 }}>
-              <h3 style={{ color: '#e2e8f0', fontSize: 16, fontWeight: 600 }}>
-                Team Integrations
-              </h3>
-              <p style={{ color: '#94a3b8', fontSize: 13, marginTop: 4 }}>
-                Connect your team's JIRA & GitHub. You can only configure your own team.
-              </p>
-
-              {myTeamError && (
-                <div style={{
-                  marginTop: 12, padding: 10, borderRadius: 8,
-                  background: '#450a0a', border: '1px solid #7f1d1d',
-                  color: '#fca5a5', fontSize: 13,
-                }}>
-                  {myTeamError}
-                </div>
-              )}
-
-              {myTeam ? (
-                <>
-                  <IntegrationStatusCard teamId={myTeam.teamId} />
-                  <TeamIntegrationsForm team={myTeam} />
-                </>
-              ) : !myTeamError ? (
-                <div style={{
-                  marginTop: 12, color: '#94a3b8', fontSize: 13,
-                }}>
-                  Loading your team…
-                </div>
-              ) : null}
-            </div>
-          </>
-        ) : null}
-      </div>
-
+        {/* Aside: helpful links */}
+        <aside>
           <div className="rounded-2xl border border-[#1f1f23] bg-[#0e0e10] p-5">
             <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
               Quick links
@@ -266,6 +191,14 @@ const IntegrationsPage = () => {
                 className="flex items-center gap-2 text-[12.5px] text-zinc-400 transition hover:text-zinc-100"
               >
                 <Link2 size={12} /> GitHub OAuth docs ↗
+              </a>
+              <a
+                href="https://id.atlassian.com/manage-profile/security/api-tokens"
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-2 text-[12.5px] text-zinc-400 transition hover:text-zinc-100"
+              >
+                <Link2 size={12} /> Atlassian API tokens ↗
               </a>
               <a
                 href="#"

--- a/frontend/src/pages/ScrumManagementPage.jsx
+++ b/frontend/src/pages/ScrumManagementPage.jsx
@@ -88,22 +88,40 @@ function ScrumManagementPage() {
 
     try {
       const response = await apiClient.get(apiConfig.endpoints.teamSync(teamId));
-      const data = response.data || {};
+      const raw = response.data;
 
-      const summary = {
-        syncRunId: data.syncRunId || data.lastSyncRunId || '',
-        totalIssues: data.totalIssues ?? 0,
-        linkedCount: data.linkedCount ?? 0,
-        syncedAt: data.syncedAt || data.lastSyncedAt || null,
-      };
-
-      const issueRows = Array.isArray(data.issues)
-        ? data.issues
-        : Array.isArray(data.data)
-        ? data.data
+      // Backend GET /teams/:id/sync returns the sprint-stories array directly
+      // (no envelope). Derive summary fields from it; preserve any prior
+      // syncRunId since GET does not expose it.
+      const issueRows = Array.isArray(raw)
+        ? raw
+        : Array.isArray(raw?.issues)
+        ? raw.issues
+        : Array.isArray(raw?.data)
+        ? raw.data
         : [];
 
-      setSyncSummary(summary);
+      const latestSyncedAt = issueRows.reduce((latest, row) => {
+        if (!row?.syncedAt) return latest;
+        const t = new Date(row.syncedAt).getTime();
+        return Number.isFinite(t) && t > latest ? t : latest;
+      }, 0);
+
+      const linkedCount = issueRows.filter(
+        (r) => r && r.githubStatus && r.githubStatus !== 'no_branch',
+      ).length;
+
+      setSyncSummary((prev) => ({
+        syncRunId: prev?.syncRunId || raw?.syncRunId || raw?.lastSyncRunId || '',
+        totalIssues: issueRows.length || raw?.totalIssues || 0,
+        linkedCount: linkedCount || raw?.linkedCount || 0,
+        syncedAt:
+          (latestSyncedAt && new Date(latestSyncedAt).toISOString()) ||
+          raw?.syncedAt ||
+          raw?.lastSyncedAt ||
+          prev?.syncedAt ||
+          null,
+      }));
       setIssues(issueRows);
     } catch (error) {
       const status = error?.response?.status;
@@ -287,23 +305,45 @@ function ScrumManagementPage() {
                       <th className="py-2 pr-4">Issue Key</th>
                       <th className="py-2 pr-4">Summary</th>
                       <th className="py-2 pr-4">Status</th>
-                      <th className="py-2 pr-4">Branch Found</th>
-                      <th className="py-2">PR Found</th>
+                      <th className="py-2 pr-4">Points</th>
+                      <th className="py-2 pr-4">Branch</th>
+                      <th className="py-2 pr-4">PR</th>
+                      <th className="py-2 pr-4">GitHub</th>
+                      <th className="py-2">Complete</th>
                     </tr>
                   </thead>
                   <tbody>
                     {issues.map((issue) => {
-                      const branchFound = Boolean(issue.githubBranchFound);
-                      const prFound = Boolean(issue.githubPrFound);
-                      const rowClass = !branchFound || !prFound ? 'bg-amber-500/10' : '';
+                      const gh = issue.githubStatus || 'no_branch';
+                      const branchFound = gh !== 'no_branch';
+                      const prFound = gh !== 'no_branch' && gh !== 'no_pr';
+                      const complete = !!issue.isComplete;
+                      const rowClass = complete
+                        ? 'bg-emerald-500/5'
+                        : !branchFound || !prFound
+                        ? 'bg-amber-500/10'
+                        : '';
+
+                      const ghLabel = {
+                        no_branch: { text: 'No Branch', color: 'text-slate-400' },
+                        no_pr: { text: 'No PR', color: 'text-amber-400' },
+                        pr_not_merged: { text: 'PR Open', color: 'text-sky-400' },
+                        author_mismatch: { text: 'Author Mismatch', color: 'text-fuchsia-400' },
+                        verified: { text: 'Verified ✓', color: 'text-emerald-400' },
+                      }[gh] || { text: gh, color: 'text-slate-300' };
 
                       return (
                         <tr key={issue.issueKey || issue.key} className={`border-b border-[#1e293b] ${rowClass}`}>
-                          <td className="py-2 pr-4 text-slate-100">{issue.issueKey || issue.key || '—'}</td>
+                          <td className="py-2 pr-4 text-slate-100 font-mono">{issue.issueKey || issue.key || '—'}</td>
                           <td className="py-2 pr-4 text-slate-300">{issue.summary || '—'}</td>
-                          <td className="py-2 pr-4 text-slate-300">{issue.status || '—'}</td>
+                          <td className="py-2 pr-4 text-slate-300">{issue.resolution || issue.status || '—'}</td>
+                          <td className="py-2 pr-4 text-slate-300">{issue.work ?? 0}</td>
                           <td className="py-2 pr-4 text-slate-300">{branchFound ? 'Yes' : 'No'}</td>
-                          <td className="py-2 text-slate-300">{prFound ? 'Yes' : 'No'}</td>
+                          <td className="py-2 pr-4 text-slate-300">{prFound ? 'Yes' : 'No'}</td>
+                          <td className={`py-2 pr-4 ${ghLabel.color}`}>{ghLabel.text}</td>
+                          <td className={`py-2 ${complete ? 'text-emerald-400 font-bold' : 'text-slate-500'}`}>
+                            {complete ? '✓ YES' : 'no'}
+                          </td>
                         </tr>
                       );
                     })}


### PR DESCRIPTION
## Summary

End-to-end JIRA + GitHub sprint integration for team leaders, plus a coordinator-grade verification path. A team leader links one JIRA project + GitHub repo via a guided form; a daily cron (and a boot-time + manual trigger) syncs sprint issues, verifies merged PRs, checks PR author against the JIRA assignee's linked GitHub account, and exposes the live state to advisors and coordinators.

---

## Type of Change
- [x] Feature (new endpoint or business logic)
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [x] Configuration / infrastructure (new env var `INTEGRATION_ENCRYPTION_KEY`)
- [x] Background job / scheduled task
- [x] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change

**Backend:**
- Controller(s):
  - `backend/src/teams/teams.controller.ts` — new routes (`GET /teams`, `GET /teams/mine`, `POST /teams/jira/discover`, `GET /teams/:id/integrations/status`), per-role scoping for sync and advisor-panel.
  - `backend/src/groups/groups.controller.ts` — `GET /groups` opened to Professor/TeamLeader/Student with auto-scoped filtering.
- Use case(s) / service(s):
  - `backend/src/teams/teams.service.ts` — `findOrCreateMyTeam`, `discoverJira`, `findGroupIdsAdvisedBy`, `findByIdOrGroupId`, encrypted credential persistence, group-name inline join.
  - `backend/src/teams/teams-sync.service.ts` — issue sync rewritten to use the docs-canonical `/board/{boardId}/sprint/{sprintId}/issue` path, configurable story-points custom field, PR author verification, AES-GCM token decryption, integration health probe (`getIntegrationStatus`), per-issue structured logging.
  - `backend/src/teams/teams-cron.service.ts` — boot-time sync (`OnApplicationBootstrap`), per-team auto-finalize on overdue sprints.
  - `backend/src/groups/groups.service.ts` — Group→Team mirroring on `createGroupByStudent`, advisor-scoped `findAll`.
  - `backend/src/sprint-configs/sprint-configs.service.ts` — fan-out `notifySprintScheduled` to team leaders on create/update.
  - `backend/src/auth/guards/roles.guard.ts` — case-tolerant role match, descriptive 403 message.
  - `backend/src/teams/guards/team-leader.guard.ts` — accept ObjectId or groupId in URL, JWT-correct caller id resolution.
- Repository / DB layer:
  - Mongoose-backed lookups in `teams.service.ts`, `teams-sync.service.ts`, `groups.service.ts`.
- Schema / migration:
  - `backend/src/teams/schemas/team.schema.ts` — added `groupId`, `jiraBoardId`, `jiraStoryPointsField`.
  - `backend/src/teams/schemas/sprint-story.schema.ts` — added `prAuthorLogin`, new `GithubStatus.AUTHOR_MISMATCH`.
  - `backend/src/notifications/schemas/notification.schema.ts` — `groupId` optional, `data` payload.
  - `backend/src/story-points/schemas/sprint-config.schema.ts` — added `name`, `isFinalized`.
- New module:
  - `backend/src/common/crypto/secret-cipher.ts` — AES-256-GCM encrypt/decrypt for JIRA token + GitHub PAT.
- DTOs:
  - `backend/src/teams/dto/jira-discover.dto.ts` (new), `update-integrations.dto.ts` (new fields), `finalize-sprint.dto.ts`.
- OpenAPI spec file(s): not regenerated in this branch.

**Frontend:**
- Components:
  - `frontend/src/components/TeamIntegrationsForm.jsx` — wizard form with Discover button, board dropdown, group readonly chip.
  - `frontend/src/components/IntegrationStatusCard.jsx` — live JIRA/GitHub health card with badges.
- Pages:
  - `frontend/src/pages/IntegrationsPage.jsx` — auto-loads the leader's own team via `GET /teams/mine`.
  - `frontend/src/pages/AdvisorSprintPanel.jsx` — Team dropdown, "Run Sync Now" button, Author Mismatch badge.
  - `frontend/src/pages/SprintFinalizePage.jsx` — Team + Sprint dropdowns (no raw IDs).
  - `frontend/src/pages/ScrumManagementPage.jsx` — fixed sync summary (was clobbering POST data with GET array), expanded issue table with Status / Points / GitHub badge / Complete columns derived from `githubStatus`.
- API client:
  - `frontend/src/config/api.js` — new endpoints: `teamMine`, `teamJiraDiscover`, `teamIntegrationsStatus`, `teamsList`.

**Infrastructure / Config:**
- New env var `INTEGRATION_ENCRYPTION_KEY` (32+ char). Falls back to a derived dev key when missing, with a server-side warning.
- Boot-time sync runs ~5 s after process start. Disable with `SKIP_BOOT_SYNC=1`.
- Optional `SYNC_DEBUG=1` dumps the first issue's JIRA fields to logs for misconfig debugging.

---

## API Contract Alignment

| Field | Value |
|---|---|
| Endpoints | `GET /teams`, `GET /teams/mine`, `POST /teams/jira/discover`, `PUT /teams/:id/integrations`, `GET /teams/:id/integrations/status`, `POST /teams/:id/sync`, `GET /teams/:id/advisor-panel`, `POST /teams/:id/finalize-sprint`, `GET /groups` (scoped) |
| OperationId | `listTeams`, `getMyTeam`, `jiraDiscover`, `updateIntegrations`, `getIntegrationStatus`, `syncStories`, `getAdvisorPanel`, `finalizeSprintSync`, `listGroups` |
| OpenAPI file | process5.yaml |
| Spec updated in this PR | No — endpoints are additive; spec regen is out of scope. |

- [ ] Response shape matches OpenAPI schema exactly (spec not yet regenerated)
- [x] All implemented status codes are reachable via implementation
- [x] No secrets returned in responses (`hasToken: bool` instead of token; encrypted at rest)
- [x] groupId / actorId extracted from JWT — NOT from request body

---

## Clean Architecture Checklist

**Infrastructure / API layer:**
- [x] Auth guard behavior: `JwtAuthGuard → RolesGuard / TeamLeaderGuard` chain enforced; `RolesGuard` returns descriptive 403 with required vs caller role.
- [x] Controller returns contract-compliant response shape.
- [x] Input validation rules enforced (DTOs with `class-validator`, UUID format, email format).

**Application / Use Case layer:**
- [x] Validations precede DB writes (GitHub repo + JIRA project pinged before persisting credentials).
- [x] Sensitive fields never exposed (token ciphertext stored, only `hasToken` boolean exposed).
- [x] Error mapping deterministic (mapped GitHub 401/403/404 to specific messages; JIRA 401 → 422 with auth-failed reason).

**Domain / Repository layer:**
- [x] Repository queries enforce role scoping (Professor → advised groups, TeamLeader/Student → own group).
- [x] Sprint-story uniqueness via `(teamId, issueKey)` compound unique index.
- [x] DB failures caught and mapped (token validation `try/catch` → `HttpException`).

---

## Test Evidence

**Unit tests:** none added in this branch.
**Controller tests:** none added in this branch.
**Integration / E2E tests:** none added in this branch.
**Manual / E2E:** verified end-to-end with a real Atlassian Cloud sandbox + GitHub repo:
- Team Leader fills form → Discover auto-fills board + story-points field → Save passes JIRA `/myself` + GitHub `/repos/{owner}/{repo}` probes.
- POST `/teams/:id/sync` returns `{ totalIssues, linkedCount, syncRunId }`; sprint stories persisted with `prAuthorLogin` and accurate `githubStatus`.
- Manual JIRA flip to "Done" + matching merged PR by the assignee's linked GitHub login → `isComplete=true`.
- Open PR / branch missing / non-matching PR author scenarios all surface the correct `GithubStatus` value (`pr_not_merged`, `no_branch`, `author_mismatch`).
- `GET /teams/:id/integrations/status` shows green/red badges that flip in real time after `Re-check`.

**Test run output:** N/A (no automated suite added in this branch).

---

## Status Code Matrix Verification

| Code | Scenario | Tested |
|---|---|---|
| 2xx | Sync success, integration status success, finalize | ☑ (manual) |
| 400 | Missing JIRA credentials on sync | ☑ (manual) |
| 401 | JWT missing/expired (interceptor refresh) | ☑ (manual) |
| 403 | Non-leader hits team-scoped routes; Professor hits non-advised team | ☑ (manual) |
| 404 | Team not found, integration status with unknown id | ☑ (manual) |
| 422 | JIRA auth/validation failure during integration save / discover | ☑ (manual) |
| 500 | DB / unexpected → mapped to generic 500 | ☐ |

---

## Observability Checklist
- [x] Per-issue sync log lines: `pts / jira / github / complete / assignee / pr@author (expected @x)`
- [x] Author-mismatch warn log with both logins
- [x] Sync run id (UUID) tagged on every story write
- [x] Boot-sync schedule and per-team success/failure counts logged
- [x] No secrets/tokens in logs (decrypted only in-memory; logs reference field names, not values)
- [ ] 500s surface internal context (mostly handled, some catch-all paths still generic)
- [ ] Audit log entry — depends on Issue 47, not implemented in this branch

---

## Migration / Breaking Change Assessment
- [x] No database migration required — new fields are optional with defaults. Legacy plaintext token rows still decrypt correctly (decrypt is identity for non-`iv:tag:cipher` shapes).
- [x] No breaking change to existing API contracts — every change is additive (new fields in responses, new endpoints, expanded role lists).
- [x] Backward compatibility: `URL :teamId` path parameter accepts either Mongo `_id` or `groupId` UUID; old callers work, new wizards use UUID.

---

## Out of Scope Confirmation
The following are explicitly out of scope for this PR:
- OpenAPI regeneration (`process5.yaml`).
- Automated test additions (unit / controller / e2e). Manual verification only.
- OAuth 2.0 (3LO) flow with JIRA — the API token + Basic Auth path is implemented; webhook subscription requires OAuth which is a separate effort.
- Branch / PR matching upgrade from `includes()` substring to a regex word-boundary check (known false-positive risk: `ALPHA-1` matches `ALPHA-10` branches when ≥10 issues exist).
- Grade calculation consumption of `StoryPointRecord` — sprint finalize writes the records; downstream grading is a separate workstream.

---

## Dependencies
- Blocked by: #N/A
- Must be merged before: #N/A
- Requires Issue 47 (Audit logging) to be merged first: No

---

## Reviewer Notes

**What to look at first**
1. `teams-sync.service.ts verifyGithub` — new strict author check + `AUTHOR_MISMATCH` enum. Strict mode means a merged PR by a teammate **does not** count as the assignee's completion.
2. `teams.service.ts findByIdOrGroupId` — accepts both Mongo `_id` and groupId UUID. Multiple call-sites depend on this; URLs in the wild may use either.
3. `common/crypto/secret-cipher.ts` — token encryption format is `iv:tag:ciphertext` base64. Decrypt is permissive (returns input unchanged if not in this shape) so legacy rows keep working.
4. `groups.service.ts createGroupByStudent` — now upserts a `Team` doc keyed by `leaderId` and pre-links `groupId`. Existing leaders without a Team get one via `GET /teams/mine` lazily.

**Edge cases handled**
- `?cloudId=...` querystring stripped from JIRA accountId on save and on read.
- Author check is skipped when assignee has no linked GitHub account (graceful degradation).
- Boot sync wrapped in `try/catch`; cron path failures don't crash the process.

**Known follow-ups (not addressed here)**
- `ALPHA-1` vs `ALPHA-10` substring collision in branch matching.
- Mongoose deprecation warning on `{ new: true }` option (not blocking).
- Sprint history UI for completed sprints.

---

## Definition of Done Sign-off
- [x] Implementation merged with passing manual verification
- [ ] OpenAPI spec updated and aligned with implementation
- [x] QA scenarios executed and evidenced above
- [x] PR description includes test evidence and status-matrix coverage
- [x] No TODO comments left in production code
- [x] No console.log or debug statements left in code (gated `SYNC_DEBUG=1` for opt-in raw dump)
