### PR TITLE
fixed: professor can access /review

### DIFF
--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import SubmissionReviewPanel from '../components/reviews/SubmissionReviewPanel'
 import { getCommittee, listCommittees } from '../utils/committeeService'
-import { getSubmissionsForCommittee } from '../utils/reviewService'
+import {
+  getSubmissionsForCommittee,
+  listProfessorReviewSubmissions,
+} from '../utils/reviewService'
+import apiClient from '../utils/apiClient'
+import apiConfig from '../config/api'
 import { PageHeader, Badge } from '../components/ui'
 
 const normalizeList = (payload) => {
@@ -57,6 +62,7 @@ const getStoredUser = () => {
 const ReviewPage = () => {
   const [user, setUser] = useState(null)
   const [committee, setCommittee] = useState(null)
+  const [committeeFromGroup, setCommitteeFromGroup] = useState(null)
   const [submissions, setSubmissions] = useState([])
   const [selectedSubmissionId, setSelectedSubmissionId] = useState('')
   const [status, setStatus] = useState({ loading: true, error: '' })
@@ -92,9 +98,19 @@ const ReviewPage = () => {
       let professorCommittee = null
       if (directCommitteeId) {
         professorCommittee = await getCommittee(directCommitteeId)
+      } else if (String(localUser.role || '').toLowerCase() === 'professor') {
+        const queue = normalizeList(await listProfessorReviewSubmissions())
+        setCommittee(null)
+        setCommitteeFromGroup(null)
+        setSubmissions(queue)
+        setSelectedSubmissionId(
+          String(queue[0]?._id || queue[0]?.id || queue[0]?.submissionId || ''),
+        )
+        setStatus({ loading: false, error: '' })
+        return
       } else {
         const committees = normalizeList(await listCommittees({ page: 1, limit: 100 }))
-        professorCommittee = findProfessorCommittee(committees, localUser) || committees[0] || null
+        professorCommittee = findProfessorCommittee(committees, localUser) || null
       }
 
       const committeeId = getCommitteeId(professorCommittee)
@@ -125,13 +141,37 @@ const ReviewPage = () => {
     return () => window.clearTimeout(task)
   }, [loadReviewQueue])
 
-  const committeeId = getCommitteeId(committee)
+  useEffect(() => {
+    const groupId = selectedSubmission?.groupId
+    if (!groupId) {
+      setCommitteeFromGroup(null)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const { data } = await apiClient.get(apiConfig.endpoints.groupCommittee(groupId))
+        if (cancelled) return
+        const id = data?.id || data?.committeeId || data?._id
+        setCommitteeFromGroup(id ? { id, name: data?.name } : null)
+      } catch {
+        if (!cancelled) setCommitteeFromGroup(null)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [selectedSubmission])
+
+  const committeeId = getCommitteeId(committee) || committeeFromGroup?.id || ''
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Review"
-        subtitle={`${committee?.name || committeeId || 'Committee'} assigned submissions`}
+        subtitle={`${
+          committee?.name || committeeFromGroup?.name || committeeId || 'Committee'
+        } assigned submissions`}
       />
 
       {status.loading && (

--- a/frontend/src/utils/reviewService.js
+++ b/frontend/src/utils/reviewService.js
@@ -62,3 +62,10 @@ export async function getSubmissionsForCommittee(committeeId) {
     'Unable to fetch committee submissions.',
   )
 }
+
+export async function listProfessorReviewSubmissions() {
+  return request(
+    () => apiClient.get(apiConfig.endpoints.submissions.list),
+    'Unable to fetch submissions.',
+  )
+}


### PR DESCRIPTION
## Summary

Fixes the review queue for professor accounts that do not have a `committeeId` (or equivalent) on the stored user profile: the queue is now loaded via `GET /submissions`, which matches the backend path that returns submissions the professor may access (`findAllForProfessor`). List payloads are normalized whether the API returns a bare array or a wrapped `{ data: [...] }` shape. When needed, `committeeId` for `SubmissionReviewPanel` is resolved from the selected submission’s group using `GET /groups/:groupId/committee`.

Closes #267 

---

## Type of Change

- [ ] Feature (new endpoint or business logic)
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Configuration / infrastructure
- [ ] Background job / scheduled task
- [ ] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change

**Backend:**

- Controller(s): —
- Use case(s) / service(s): —
- Repository / DB layer: —
- Schema / migration: —
- OpenAPI spec file(s): —

**Frontend:**

- Component(s): `ReviewPage.jsx` (queue loading, response normalization, committee resolution from selected submission’s group)
- API client / DTO: `reviewService.js` (`listProfessorReviewSubmissions` → `GET /submissions`)

**Infrastructure / Config:** —

---

## API Contract Alignment

| Field | Value |
| --- | --- |
| Endpoint | `GET /api/v1/submissions` (no query; `Professor` role), and when needed `GET /api/v1/groups/{groupId}/committee` |
| OperationId | *(per your Swagger doc — unchanged by this PR)* |
| OpenAPI file | N/A *(this PR does not edit spec files)* |
| Spec updated in this PR | N/A |

- [ ] Response shape matches OpenAPI schema exactly *(no backend change; assumes existing contract)*
- [ ] All documented status codes are reachable via implementation
- [ ] No fields added to response that are not in the spec
- [x] groupId / actorId extracted from JWT — NOT from request body (if applicable)

---

## Clean Architecture Checklist

**Infrastructure / API layer:** — *(frontend-only PR)*

**Application / Use Case layer:** —

**Domain / Repository layer:** —

---

## Test Evidence

Lightweight bug fix; no new automated tests added or required for merge per team preference.

**Unit tests:** N/A

**Controller tests:** N/A

**Integration / E2E tests:** Optional manual smoke: sign in as Professor → Review page lists submissions → select one → panel behaves correctly.

**Test file locations:** —

**Test run output:** —

---

## Status Code Matrix Verification

This PR only consumes existing endpoints; no new status-code matrix verification for server changes.

| Code | Scenario | Tested |
| --- | --- | --- |
| 2xx | Happy path | ☐ Manual |
| 400 | Validation failure | N/A |
| 401 | Missing/invalid JWT | ☐ *(via existing auth)* |
| 403 | Role or ownership mismatch | ☐ *(if applicable)* |
| 404 | Resource not found | ☐ *(if applicable)* |
| 409 | Conflict | N/A |
| 500 | DB/internal failure | N/A |

---

## Observability Checklist

- [ ] Key business event is logged with correlationId / requestId
- [x] No secrets, tokens, hashes, or sensitive personal data in logs *(no new logging)*
- [ ] 500 responses include actionable internal context in server logs
- [ ] Audit log entry written (if this is a POST, PATCH, or DELETE operation — requires Issue 47 to be merged first)

---

## Migration / Breaking Change Assessment

- [x] No database migration required
- [ ] Migration included and tested with rollback plan
- [x] No breaking change to API contract
- [ ] Breaking change — existing consumers notified: [describe]
- [x] Backward compatibility note: N/A — client only adjusts which existing endpoints are called and how responses are parsed

---

## Out of Scope Confirmation

The following are explicitly out of scope for this PR and were not implemented:

- Backend or OpenAPI changes
- New endpoints or business rules
- Broad automated test coverage

---

## Dependencies

- Blocked by: #
- Must be merged before: #

---

## Reviewer Notes

- Worth confirming for **Professor** users **without** a stored `committeeId`: queue populates via `listProfessorReviewSubmissions`; wrapped list responses are handled by `normalizeList`; `committeeId` can come from `committeeFromGroup` after selecting a submission.

---

## Definition of Done Sign-off

- [ ] Implementation merged with passing tests
- [ ] OpenAPI spec updated and aligned with implementation *(N/A)*
- [ ] QA scenarios executed and evidenced above
- [ ] PR description includes test evidence and status-matrix coverage
- [x] No TODO comments left in production code
- [x] No console.log or debug statements left in code