### PR TITLE
326 feat backend activity logging admin activity logs UI alignment

### DIFF
--- a/backend/src/activity-logs/activity-logs.module.ts
+++ b/backend/src/activity-logs/activity-logs.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { ActivityLog, ActivityLogSchema } from './schemas/activity-log.schema';
 import { ActivityLogsService } from './activity-logs.service';
+import { User, UserSchema } from '../users/data/user.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: ActivityLog.name, schema: ActivityLogSchema },
+      { name: User.name, schema: UserSchema },
     ]),
   ],
   providers: [ActivityLogsService],

--- a/backend/src/activity-logs/activity-logs.service.spec.ts
+++ b/backend/src/activity-logs/activity-logs.service.spec.ts
@@ -4,6 +4,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Types } from 'mongoose';
 import { ActivityLogsService } from './activity-logs.service';
 import { ActivityLog } from './schemas/activity-log.schema';
+import { User } from '../users/data/user.schema';
 import { ListActivityLogsQueryDto } from './dto/list-activity-logs-query.dto';
 
 describe('ActivityLogsService', () => {
@@ -27,12 +28,23 @@ describe('ActivityLogsService', () => {
     countDocuments: jest.fn(() => mockCountChain),
   };
 
+  const mockUserModel = {
+    find: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ActivityLogsService,
         { provide: getModelToken(ActivityLog.name), useValue: mockModel },
+        { provide: getModelToken(User.name), useValue: mockUserModel },
       ],
     }).compile();
 

--- a/backend/src/activity-logs/activity-logs.service.ts
+++ b/backend/src/activity-logs/activity-logs.service.ts
@@ -10,6 +10,7 @@ import {
   ActivityLog,
   ActivityLogDocument,
 } from './schemas/activity-log.schema';
+import { User, UserDocument } from '../users/data/user.schema';
 import { ListActivityLogsQueryDto } from './dto/list-activity-logs-query.dto';
 import { ActivityLogDto } from './dto/activity-log.dto';
 import { PaginatedActivityLogsDto } from './dto/paginated-activity-logs.dto';
@@ -41,6 +42,8 @@ export class ActivityLogsService {
   constructor(
     @InjectModel(ActivityLog.name)
     private readonly activityLogModel: Model<ActivityLogDocument>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
   ) {}
 
   redactMetadata<T>(value: T): T {
@@ -85,6 +88,19 @@ export class ActivityLogsService {
         `Failed to persist activity log: ${(err as Error).message}`,
       );
       throw new InternalServerErrorException('Failed to record activity');
+    }
+  }
+
+  /**
+   * Records an activity log without failing the caller if persistence fails.
+   */
+  async safeCreate(input: CreateActivityLogInput): Promise<void> {
+    try {
+      await this.create(input);
+    } catch (err) {
+      this.logger.warn(
+        `Activity log skipped for ${input.eventType}: ${(err as Error).message}`,
+      );
     }
   }
 
@@ -141,12 +157,75 @@ export class ActivityLogsService {
       );
     }
 
+    const data = docs.map((d) => this.toDto(d));
+    await this.attachActorProfiles(data);
+
     return {
-      data: docs.map((d) => this.toDto(d)),
+      data,
       page,
       limit,
       total,
     };
+  }
+
+  private async attachActorProfiles(dtos: ActivityLogDto[]): Promise<void> {
+    const uniqueIds = [
+      ...new Set(
+        dtos
+          .map((d) => d.actorUserId)
+          .filter((id): id is string => typeof id === 'string' && !!id),
+      ),
+    ];
+    if (!uniqueIds.length) {
+      return;
+    }
+
+    let users: Array<{
+      _id: Types.ObjectId;
+      name?: string;
+      email?: string;
+    }>;
+    try {
+      users = await this.userModel
+        .find({
+          _id: {
+            $in: uniqueIds.map((id) => new Types.ObjectId(id)),
+          },
+        })
+        .select({ name: 1, email: 1 })
+        .lean()
+        .exec();
+    } catch (err) {
+      this.logger.warn(
+        `Could not resolve actor names for activity logs: ${(err as Error).message}`,
+      );
+      return;
+    }
+
+    const byId = new Map(
+      users.map((u) => {
+        const id = (u as { _id: Types.ObjectId })._id.toString();
+        return [
+          id,
+          {
+            name: (u as { name?: string }).name ?? null,
+            email: (u as { email?: string }).email ?? null,
+          },
+        ] as const;
+      }),
+    );
+
+    for (const d of dtos) {
+      if (!d.actorUserId) {
+        continue;
+      }
+      const profile = byId.get(d.actorUserId);
+      if (!profile) {
+        continue;
+      }
+      d.actorName = profile.name?.trim() ? profile.name.trim() : null;
+      d.actorEmail = profile.email ?? null;
+    }
   }
 
   private toDto(doc: ActivityLogDocument): ActivityLogDto {
@@ -159,6 +238,8 @@ export class ActivityLogsService {
       actorUserId: raw.actorUserId
         ? (raw.actorUserId as { toString(): string }).toString()
         : null,
+      actorName: null,
+      actorEmail: null,
       actorRole: (raw.actorRole as string | undefined) ?? null,
       targetType: (raw.targetType as string | undefined) ?? null,
       targetId: (raw.targetId as string | undefined) ?? null,

--- a/backend/src/activity-logs/dto/activity-log.dto.ts
+++ b/backend/src/activity-logs/dto/activity-log.dto.ts
@@ -13,6 +13,18 @@ export class ActivityLogDto {
   @ApiPropertyOptional({ nullable: true })
   actorUserId?: string | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Resolved from User.name when actorUserId is set',
+  })
+  actorName?: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Resolved from User.email when actorUserId is set',
+  })
+  actorEmail?: string | null;
+
   @ApiPropertyOptional({ nullable: true })
   actorRole?: string | null;
 

--- a/backend/src/admin/admin.controller.spec.ts
+++ b/backend/src/admin/admin.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { Role } from '../auth/enums/role.enum';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 describe('AdminController - RBAC Matrix Validation', () => {
   let controller: AdminController;
@@ -11,7 +12,10 @@ describe('AdminController - RBAC Matrix Validation', () => {
     adminService = { getActivityLogs: jest.fn() };
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AdminController],
-      providers: [{ provide: AdminService, useValue: adminService }],
+      providers: [
+        { provide: AdminService, useValue: adminService },
+        { provide: ActivityLogsService, useValue: { create: jest.fn() } },
+      ],
     }).compile();
 
     controller = module.get<AdminController>(AdminController);

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Body,
   Query,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import { AdminService } from './admin.service';
@@ -24,22 +25,50 @@ import {
 } from '@nestjs/swagger';
 import { ListActivityLogsQueryDto } from '../activity-logs/dto/list-activity-logs-query.dto';
 import { PaginatedActivityLogsDto } from '../activity-logs/dto/paginated-activity-logs.dto';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
+import type { Request } from 'express';
+
+type RequestWithUser = Request & {
+  user?: {
+    userId?: string;
+    role?: string;
+  };
+};
 
 @ApiTags('Admin')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('admin')
 export class AdminController {
-  constructor(private readonly adminService: AdminService) {}
+  constructor(
+    private readonly adminService: AdminService,
+    private readonly activityLogsService: ActivityLogsService,
+  ) {}
 
   @Patch('students/:studentId/group')
   @Roles(Role.Coordinator, Role.Admin)
   @ApiOperation({ summary: 'Move a student to a different group' })
   async moveStudentToGroup(
+    @Req() req: RequestWithUser,
     @Param('studentId') studentId: string,
     @Body() body: MoveStudentDto,
   ) {
-    return this.adminService.moveStudentToGroup(studentId, body.groupId);
+    const updatedUser = await this.adminService.moveStudentToGroup(
+      studentId,
+      body.groupId,
+    );
+    await this.activityLogsService.create({
+      eventType: 'ADMIN_STUDENT_MOVED_GROUP',
+      summary: 'Student moved to another group',
+      actorUserId: req.user?.userId,
+      actorRole: req.user?.role,
+      targetType: 'user',
+      targetId: studentId,
+      metadata: {
+        newGroupId: body.groupId,
+      },
+    });
+    return updatedUser;
   }
 
   @Get('advisor-validation')
@@ -52,8 +81,26 @@ export class AdminController {
   @Post('sanitization/execute')
   @Roles(Role.Coordinator, Role.Admin)
   @ApiOperation({ summary: 'Clean up groups without advisors (Destructive)' })
-  async executeSanitization(@Body() body: SanitizeGroupsDto) {
-    return this.adminService.executeSanitization(body.sanitizationRunDateTime);
+  async executeSanitization(
+    @Req() req: RequestWithUser,
+    @Body() body: SanitizeGroupsDto,
+  ) {
+    const result = await this.adminService.executeSanitization(
+      body.sanitizationRunDateTime,
+    );
+    await this.activityLogsService.create({
+      eventType: 'ADMIN_GROUP_SANITIZATION_EXECUTED',
+      summary: 'Group sanitization executed',
+      actorUserId: req.user?.userId,
+      actorRole: req.user?.role,
+      targetType: 'group',
+      targetId: 'sanitization',
+      metadata: {
+        deletedGroupsCount: (result as Record<string, unknown>)
+          .deletedGroupsCount,
+      },
+    });
+    return result;
   }
 
   @Get('activity')
@@ -72,17 +119,42 @@ export class AdminController {
   @Post('users/:userId/send-password-reset')
   @Roles(Role.Admin, Role.Coordinator)
   @ApiOperation({ summary: 'Send a password reset link to a specific user' })
-  async sendPasswordReset(@Param('userId') userId: string) {
-    return this.adminService.sendPasswordResetForUser(userId);
+  async sendPasswordReset(
+    @Req() req: RequestWithUser,
+    @Param('userId') userId: string,
+  ) {
+    const result = await this.adminService.sendPasswordResetForUser(userId);
+    await this.activityLogsService.create({
+      eventType: 'ADMIN_PASSWORD_RESET_SENT',
+      summary: 'Admin sent password reset email',
+      actorUserId: req.user?.userId,
+      actorRole: req.user?.role,
+      targetType: 'user',
+      targetId: userId,
+    });
+    return result;
   }
 
   @Patch('users/:userId/role')
   @Roles(Role.Coordinator, Role.Admin)
   @ApiOperation({ summary: "Update a user's role" })
   async updateUserRole(
+    @Req() req: RequestWithUser,
     @Param('userId') userId: string,
     @Body() body: UpdateUserRoleDto,
   ) {
-    return this.adminService.updateUserRole(userId, body.role);
+    const result = await this.adminService.updateUserRole(userId, body.role);
+    await this.activityLogsService.create({
+      eventType: 'ADMIN_USER_ROLE_UPDATED',
+      summary: 'User role updated',
+      actorUserId: req.user?.userId,
+      actorRole: req.user?.role,
+      targetType: 'user',
+      targetId: userId,
+      metadata: {
+        role: body.role,
+      },
+    });
+    return result;
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -9,11 +9,13 @@ import { JwtStrategy } from './jwt.strategy';
 import { RolesGuard } from './guards/roles.guard';
 import { UsersModule } from '../users/users.module';
 import { MailModule } from '../mail/mail.module';
+import { ActivityLogsModule } from '../activity-logs/activity-logs.module';
 
 @Module({
   imports: [
     UsersModule,
     MailModule,
+    ActivityLogsModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -4,6 +4,8 @@ import { BadRequestException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
+import { MailService } from '../mail/mail.service';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -22,6 +24,12 @@ describe('AuthService', () => {
   const mockJwtService = {
     signAsync: jest.fn(),
   } as any;
+  const mockMailService = {
+    sendPasswordReset: jest.fn(),
+  } as any;
+  const mockActivityLogsService = {
+    create: jest.fn(),
+  } as any;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -36,6 +44,14 @@ describe('AuthService', () => {
         {
           provide: JwtService,
           useValue: mockJwtService,
+        },
+        {
+          provide: MailService,
+          useValue: mockMailService,
+        },
+        {
+          provide: ActivityLogsService,
+          useValue: mockActivityLogsService,
         },
       ],
     }).compile();

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -12,6 +12,7 @@ import * as crypto from 'crypto';
 import { UsersService } from '../users/users.service';
 import { MailService } from '../mail/mail.service';
 import { Role } from './enums/role.enum';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 @Injectable()
 export class AuthService {
@@ -21,7 +22,36 @@ export class AuthService {
     private readonly usersService: UsersService,
     private readonly jwt: JwtService,
     private readonly mailService: MailService,
+    private readonly activityLogsService: ActivityLogsService,
   ) {}
+
+  private async recordActivity(
+    eventType: string,
+    summary: string,
+    options?: {
+      actorUserId?: string;
+      actorRole?: string;
+      targetType?: string;
+      targetId?: string;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<void> {
+    try {
+      await this.activityLogsService.create({
+        eventType,
+        summary,
+        actorUserId: options?.actorUserId,
+        actorRole: options?.actorRole,
+        targetType: options?.targetType,
+        targetId: options?.targetId,
+        metadata: options?.metadata,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Activity log skipped for ${eventType}: ${(error as Error).message}`,
+      );
+    }
+  }
 
   async register(email: string, password: string, role: Role = Role.Student) {
     if (!email || !password) {
@@ -46,6 +76,20 @@ export class AuthService {
       });
 
       this.logger.log(`User registered successfully: ${email} as ${role}`);
+      await this.recordActivity(
+        'AUTH_USER_REGISTERED',
+        'User account created',
+        {
+          actorUserId: user._id.toString(),
+          actorRole: user.role,
+          targetType: 'user',
+          targetId: user._id.toString(),
+          metadata: {
+            email: user.email,
+            role: user.role,
+          },
+        },
+      );
 
       return {
         id: user._id.toString(),
@@ -82,10 +126,28 @@ export class AuthService {
     const refreshHash = await bcrypt.hash(refreshToken, 12);
     const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30); // 30 days
 
-    await this.usersService.setRefreshToken(user._id.toString(), refreshHash, expiresAt);
+    await this.usersService.setRefreshToken(
+      user._id.toString(),
+      refreshHash,
+      expiresAt,
+    );
 
     this.logger.log(`User logged in successfully: ${email}`);
-    return { accessToken, refreshToken, refreshExpiresAt: expiresAt.toISOString(), userId: user._id.toString() };
+    await this.recordActivity('AUTH_LOGIN', 'User logged in', {
+      actorUserId: user._id.toString(),
+      actorRole: user.role,
+      targetType: 'user',
+      targetId: user._id.toString(),
+      metadata: {
+        email: user.email,
+      },
+    });
+    return {
+      accessToken,
+      refreshToken,
+      refreshExpiresAt: expiresAt.toISOString(),
+      userId: user._id.toString(),
+    };
   }
 
   async refreshAccessToken(refreshUserId: string, refreshToken: string) {
@@ -115,13 +177,41 @@ export class AuthService {
     const newRefreshHash = await bcrypt.hash(newRefreshToken, 12);
     const newExpiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 
-    await this.usersService.setRefreshToken(user._id.toString(), newRefreshHash, newExpiresAt);
+    await this.usersService.setRefreshToken(
+      user._id.toString(),
+      newRefreshHash,
+      newExpiresAt,
+    );
+    await this.recordActivity('AUTH_TOKEN_REFRESH', 'Access token refreshed', {
+      actorUserId: user._id.toString(),
+      actorRole: user.role,
+      targetType: 'user',
+      targetId: user._id.toString(),
+      metadata: {
+        email: user.email,
+      },
+    });
 
-    return { accessToken, refreshToken: newRefreshToken, refreshExpiresAt: newExpiresAt.toISOString(), userId: user._id.toString() };
+    return {
+      accessToken,
+      refreshToken: newRefreshToken,
+      refreshExpiresAt: newExpiresAt.toISOString(),
+      userId: user._id.toString(),
+    };
   }
 
   async logout(userId: string) {
+    const user = await this.usersService.findById(userId);
     await this.usersService.clearRefreshToken(userId);
+    await this.recordActivity('AUTH_LOGOUT', 'User logged out', {
+      actorUserId: userId,
+      actorRole: user?.role,
+      targetType: 'user',
+      targetId: userId,
+      metadata: {
+        email: user?.email ?? null,
+      },
+    });
     return { success: true };
   }
 
@@ -130,14 +220,32 @@ export class AuthService {
       throw new BadRequestException('Email is required');
     }
 
+    const user = await this.usersService.findByEmail(email);
     const token = await this.usersService.createPasswordResetToken(email);
     if (token) {
       this.logger.log(`Password reset token generated for email: ${email}`);
+      if (user) {
+        await this.recordActivity(
+          'AUTH_PASSWORD_RESET_REQUESTED',
+          'Password reset requested',
+          {
+            actorUserId: user._id.toString(),
+            actorRole: user.role,
+            targetType: 'user',
+            targetId: user._id.toString(),
+            metadata: {
+              email: user.email,
+            },
+          },
+        );
+      }
       try {
         await this.mailService.sendPasswordReset(email, token);
         this.logger.log(`Password reset email successfully sent to ${email}`);
       } catch (err) {
-        this.logger.error(`Failed to send password reset email to ${email}: ${(err as Error).message}`);
+        this.logger.error(
+          `Failed to send password reset email to ${email}: ${(err as Error).message}`,
+        );
       }
     } else {
       this.logger.warn(`Password reset requested for unknown email: ${email}`);
@@ -166,6 +274,19 @@ export class AuthService {
     );
 
     this.logger.log(`Password reset completed for email: ${user.email}`);
+    await this.recordActivity(
+      'AUTH_PASSWORD_RESET_CONFIRMED',
+      'Password reset completed',
+      {
+        actorUserId: (user._id || user.id).toString(),
+        actorRole: user.role,
+        targetType: 'user',
+        targetId: (user._id || user.id).toString(),
+        metadata: {
+          email: user.email,
+        },
+      },
+    );
     return { message: 'Password has been reset successfully.' };
   }
 
@@ -229,6 +350,18 @@ export class AuthService {
         tokenData.scope,
       );
       this.logger.log(`Successfully linked GitHub account for user: ${userId}`);
+      const user = await this.usersService.findById(userId);
+      await this.recordActivity('AUTH_GITHUB_LINKED', 'GitHub account linked', {
+        actorUserId: userId,
+        actorRole: user?.role,
+        targetType: 'user',
+        targetId: userId,
+        metadata: {
+          githubLogin: githubUser.login,
+          githubAccountId: githubUser.id?.toString?.() ?? null,
+          scopes: tokenData.scope ?? '',
+        },
+      });
 
       return {
         message: 'GitHub account linked successfully',
@@ -259,6 +392,19 @@ export class AuthService {
 
     await this.usersService.unlinkGithubAccount(userId);
     this.logger.log(`Unlinked GitHub account for user: ${userId}`);
+    await this.recordActivity(
+      'AUTH_GITHUB_UNLINKED',
+      'GitHub account unlinked',
+      {
+        actorUserId: userId,
+        actorRole: user.role,
+        targetType: 'user',
+        targetId: userId,
+        metadata: {
+          email: user.email,
+        },
+      },
+    );
     return {
       message: 'GitHub account unlinked successfully',
       isGithubConnected: false,

--- a/backend/src/grades/grades.module.ts
+++ b/backend/src/grades/grades.module.ts
@@ -33,9 +33,11 @@ import {
   CommitteeSchema,
 } from '../committees/schemas/committee.schema';
 import { User, UserSchema } from '../users/data/user.schema';
+import { ActivityLogsModule } from '../activity-logs/activity-logs.module';
 
 @Module({
   imports: [
+    ActivityLogsModule,
     DeliverablesModule,
     MongooseModule.forFeature([
       { name: StudentFinalGrade.name, schema: StudentFinalGradeSchema },

--- a/backend/src/grades/grades.service.spec.ts
+++ b/backend/src/grades/grades.service.spec.ts
@@ -1,10 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';
-import {
-  BadRequestException,
-  ConflictException,
-  NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { GradesService } from './grades.service';
 import {
   StudentFinalGrade,
@@ -22,6 +18,8 @@ import { GroupFinalGradeDto } from './dto/group-final-grade.dto';
 import { ListGradeHistoryQueryDto } from './dto/list-grade-history-query.dto';
 import { Group, GroupAssignmentStatus } from '../groups/group.entity';
 import { DeliverableGrade } from './schemas/deliverable-evaluation.schema';
+import { User } from '../users/data/user.schema';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 describe('GradesService', () => {
   let service: GradesService;
@@ -54,6 +52,11 @@ describe('GradesService', () => {
     mockDeliverableEvaluationModel = {
       create: jest.fn(),
       findOne: jest.fn(),
+      findOneAndUpdate: jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn(),
+        }),
+      }),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -98,6 +101,14 @@ describe('GradesService', () => {
         {
           provide: getModelToken(Committee.name),
           useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getModelToken(User.name),
+          useValue: { find: jest.fn() },
+        },
+        {
+          provide: ActivityLogsService,
+          useValue: { safeCreate: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();
@@ -624,15 +635,18 @@ describe('GradesService', () => {
         }),
       });
       const now = new Date('2026-05-06T10:00:00.000Z');
-      mockDeliverableEvaluationModel.create.mockResolvedValue({
-        toObject: () => ({
-          evaluationId: '33333333-3333-3333-3333-333333333333',
-          groupId: dto.groupId,
-          deliverableId: dto.deliverableId,
-          deliverableGrade: dto.deliverableGrade,
-          gradedBy: '44444444-4444-4444-4444-444444444444',
-          createdAt: now,
-          updatedAt: now,
+      const upsertDoc = {
+        evaluationId: '33333333-3333-3333-3333-333333333333',
+        groupId: dto.groupId,
+        deliverableId: dto.deliverableId,
+        deliverableGrade: dto.deliverableGrade,
+        gradedBy: '44444444-4444-4444-4444-444444444444',
+        createdAt: now,
+        updatedAt: now,
+      };
+      mockDeliverableEvaluationModel.findOneAndUpdate.mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue(upsertDoc),
         }),
       });
 
@@ -641,14 +655,16 @@ describe('GradesService', () => {
         '44444444-4444-4444-4444-444444444444',
       );
 
-      expect(mockDeliverableEvaluationModel.create).toHaveBeenCalledWith(
+      expect(mockDeliverableEvaluationModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { groupId: dto.groupId, deliverableId: dto.deliverableId },
         expect.objectContaining({
-          groupId: dto.groupId,
-          deliverableId: dto.deliverableId,
-          deliverableGrade: DeliverableGrade.B,
-          rawGrade: 80,
-          gradedBy: '44444444-4444-4444-4444-444444444444',
+          $set: expect.objectContaining({
+            deliverableGrade: DeliverableGrade.B,
+            rawGrade: 80,
+            gradedBy: '44444444-4444-4444-4444-444444444444',
+          }),
         }),
+        { upsert: true, new: true },
       );
       expect(result.gradedBy).toBe('44444444-4444-4444-4444-444444444444');
     });
@@ -687,7 +703,7 @@ describe('GradesService', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('throws ConflictException on duplicate groupId + deliverableId', async () => {
+    it('propagates duplicate key error from upsert (Mongo 11000)', async () => {
       mockDeliverableModel.findOne.mockReturnValue({
         lean: jest.fn().mockReturnValue({
           exec: jest
@@ -703,11 +719,15 @@ describe('GradesService', () => {
           }),
         }),
       });
-      mockDeliverableEvaluationModel.create.mockRejectedValue({ code: 11000 });
+      mockDeliverableEvaluationModel.findOneAndUpdate.mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockRejectedValue({ code: 11000 }),
+        }),
+      });
 
       await expect(
         service.recordDeliverableEvaluation(dto as any, 'user-id'),
-      ).rejects.toThrow(ConflictException);
+      ).rejects.toMatchObject({ code: 11000 });
     });
   });
 

--- a/backend/src/grades/grades.service.ts
+++ b/backend/src/grades/grades.service.ts
@@ -63,6 +63,7 @@ import {
 } from '../committees/schemas/committee.schema';
 import { User, UserDocument } from '../users/data/user.schema';
 import { Role } from '../auth/enums/role.enum';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 @Injectable()
 export class GradesService {
@@ -91,6 +92,7 @@ export class GradesService {
     private readonly committeeModel: Model<CommitteeDocument>,
     @InjectModel(User.name)
     private readonly userModel: Model<UserDocument>,
+    private readonly activityLogsService: ActivityLogsService,
   ) {}
 
   // ────────────────────────────────────────────────────────────────
@@ -290,6 +292,19 @@ export class GradesService {
       )
       .lean()
       .exec();
+
+    await this.activityLogsService.safeCreate({
+      eventType: 'DELIVERABLE_EVALUATION_RECORDED',
+      summary: 'Deliverable evaluation grade recorded',
+      actorUserId: gradedBy,
+      targetType: 'group',
+      targetId: dto.groupId,
+      metadata: {
+        deliverableId: dto.deliverableId,
+        deliverableGrade: dto.deliverableGrade,
+        evaluationId: (upserted as DeliverableEvaluation).evaluationId,
+      },
+    });
 
     return this.toDeliverableEvaluationResponseDto(
       upserted as unknown as DeliverableEvaluation & {
@@ -772,6 +787,20 @@ export class GradesService {
             ).toFixed(4),
           )
         : 0;
+
+    await this.activityLogsService.safeCreate({
+      eventType: 'FINAL_GRADES_CALCULATED',
+      summary: 'Final grades calculated for group',
+      actorUserId: triggeredBy,
+      targetType: 'group',
+      targetId: groupId,
+      metadata: {
+        teamGrade,
+        force: dto.force ?? false,
+        studentCount: individualGrades.length,
+        teamScalar: overallTeamScalar,
+      },
+    });
 
     return {
       groupId,

--- a/backend/src/invites/invites.controller.spec.ts
+++ b/backend/src/invites/invites.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { InvitesController } from './invites.controller';
 import { InvitesService } from './invites.service';
 import { Role } from '../auth/enums/role.enum';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 describe('InvitesController - RBAC Matrix Validation', () => {
   let controller: InvitesController;
@@ -11,6 +12,7 @@ describe('InvitesController - RBAC Matrix Validation', () => {
       controllers: [InvitesController],
       providers: [
         { provide: InvitesService, useValue: {} },
+        { provide: ActivityLogsService, useValue: { create: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/invites/invites.controller.ts
+++ b/backend/src/invites/invites.controller.ts
@@ -1,22 +1,46 @@
-import { Controller, Post, UseGuards } from '@nestjs/common';
+import { Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { Role } from '../auth/enums/role.enum';
 import { InvitesService } from './invites.service';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
+import type { Request } from 'express';
+
+type RequestWithUser = Request & {
+  user?: {
+    userId?: string;
+    role?: string;
+  };
+};
 
 @ApiTags('Invites')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('invites')
 export class InvitesController {
-  constructor(private readonly invitesService: InvitesService) {}
+  constructor(
+    private readonly invitesService: InvitesService,
+    private readonly activityLogsService: ActivityLogsService,
+  ) {}
 
   @Post('deliver')
-  @Roles(Role.Coordinator, Role.Admin) 
+  @Roles(Role.Coordinator, Role.Admin)
   @ApiOperation({ summary: 'Deliver invites to groups' })
-  async deliverInvites() {
-    return this.invitesService.deliverInvites();
+  async deliverInvites(@Req() req: RequestWithUser) {
+    const result = await this.invitesService.deliverInvites();
+    await this.activityLogsService.create({
+      eventType: 'INVITES_DELIVERED',
+      summary: 'Invite delivery triggered',
+      actorUserId: req.user?.userId,
+      actorRole: req.user?.role,
+      targetType: 'invites',
+      targetId: 'delivery',
+      metadata: {
+        status: result.status,
+      },
+    });
+    return result;
   }
 }

--- a/backend/src/invites/invites.module.ts
+++ b/backend/src/invites/invites.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { InvitesController } from './invites.controller';
 import { InvitesService } from './invites.service';
+import { ActivityLogsModule } from '../activity-logs/activity-logs.module';
 
 @Module({
+  imports: [ActivityLogsModule],
   controllers: [InvitesController],
   providers: [InvitesService],
   exports: [InvitesService], 

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -12,9 +12,11 @@ import {
 import { Review, ReviewSchema } from './schemas/review.schema';
 import { ReviewsController } from './reviews.controller';
 import { ReviewsService } from './reviews.service';
+import { ActivityLogsModule } from '../activity-logs/activity-logs.module';
 
 @Module({
   imports: [
+    ActivityLogsModule,
     MongooseModule.forFeature([
       { name: Review.name, schema: ReviewSchema },
       { name: Submission.name, schema: SubmissionSchema },

--- a/backend/src/reviews/reviews.service.spec.ts
+++ b/backend/src/reviews/reviews.service.spec.ts
@@ -15,6 +15,7 @@ import {
 } from '../submissions/schemas/submission.schema';
 import { Review, ReviewStatus } from './schemas/review.schema';
 import { ReviewsService } from './reviews.service';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 const execResult = (value: unknown) => ({
   exec: jest.fn().mockResolvedValue(value),
@@ -67,6 +68,10 @@ describe('ReviewsService', () => {
         { provide: getModelToken(Submission.name), useValue: mockSubmissionModel },
         { provide: getModelToken(Committee.name), useValue: mockCommitteeModel },
         { provide: getModelToken(Schedule.name), useValue: mockScheduleModel },
+        {
+          provide: ActivityLogsService,
+          useValue: { safeCreate: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -41,6 +41,7 @@ import {
   ReviewStatus,
   RevisionRequest,
 } from './schemas/review.schema';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 export type ReviewActor = {
   userId?: string;
@@ -57,6 +58,7 @@ export class ReviewsService {
     @InjectModel(Committee.name)
     private committeeModel: Model<CommitteeDocument>,
     @InjectModel(Schedule.name) private scheduleModel: Model<ScheduleDocument>,
+    private readonly activityLogsService: ActivityLogsService,
   ) {}
 
   private getJuryUserIds(committee: Pick<Committee, 'jury'>): string[] {
@@ -394,6 +396,22 @@ export class ReviewsService {
         )
         .exec();
     }
+
+    await this.activityLogsService.safeCreate({
+      eventType: 'REVIEW_GRADE_SUBMITTED',
+      summary: 'Committee review grade submitted',
+      actorUserId: reviewerUserId,
+      actorRole: actor.role,
+      targetType: 'review',
+      targetId: saved.reviewId,
+      metadata: {
+        submissionId: String(review.submissionId),
+        committeeId: review.committeeId,
+        grade: saved.grade,
+        allJuryGradesComplete:
+          juryUserIds.length > 0 && submittedCount === juryUserIds.length,
+      },
+    });
 
     return {
       reviewId: saved.reviewId,

--- a/backend/src/sprint-evaluations/sprint-evaluations.module.ts
+++ b/backend/src/sprint-evaluations/sprint-evaluations.module.ts
@@ -9,9 +9,11 @@ import {
   SprintEvaluation,
   SprintEvaluationSchema,
 } from './schemas/sprint-evaluation.schema';
+import { ActivityLogsModule } from '../activity-logs/activity-logs.module';
 
 @Module({
   imports: [
+    ActivityLogsModule,
     RubricsModule,
     MongooseModule.forFeature([
       { name: Group.name, schema: GroupSchema },

--- a/backend/src/sprint-evaluations/sprint-evaluations.service.spec.ts
+++ b/backend/src/sprint-evaluations/sprint-evaluations.service.spec.ts
@@ -13,6 +13,7 @@ import { Group } from '../groups/group.entity';
 import { Schedule } from '../advisors/schemas/schedule.schema';
 import { RubricsService } from '../rubrics/rubrics.service';
 import { SprintEvaluationsService } from './sprint-evaluations.service';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 import {
   SprintEvaluation,
   SprintEvaluationStatus,
@@ -54,6 +55,10 @@ describe('SprintEvaluationsService', () => {
         {
           provide: RubricsService,
           useValue: mockRubricsService,
+        },
+        {
+          provide: ActivityLogsService,
+          useValue: { safeCreate: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();

--- a/backend/src/sprint-evaluations/sprint-evaluations.service.ts
+++ b/backend/src/sprint-evaluations/sprint-evaluations.service.ts
@@ -31,6 +31,7 @@ import { CreateSprintEvaluationDto } from './dto/create-sprint-evaluation.dto';
 import { SprintEvaluationResponseDto } from './dto/sprint-evaluation-response.dto';
 import { RubricsService } from '../rubrics/rubrics.service';
 import { RubricDocument } from '../rubrics/schemas/rubric.schema';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 interface RequestContext {
   userId?: string;
@@ -48,6 +49,7 @@ export class SprintEvaluationsService {
     @InjectModel(SprintEvaluation.name)
     private readonly sprintEvaluationModel: Model<SprintEvaluationDocument>,
     private readonly rubricsService: RubricsService,
+    private readonly activityLogsService: ActivityLogsService,
   ) {}
 
   async recordSprintEvaluation(
@@ -94,6 +96,29 @@ export class SprintEvaluationsService {
       evaluationType: dto.evaluationType,
       rubricId: rubric.rubricId,
       correlationId,
+    });
+
+    const rubricGrades = dto.responses.map((r) => ({
+      questionId: r.questionId,
+      softGrade: r.softGrade,
+    }));
+
+    await this.activityLogsService.safeCreate({
+      eventType: 'SPRINT_EVALUATION_SUBMITTED',
+      summary: `Sprint evaluation (rubric) submitted — average score ${Number(averageScore).toFixed(2)}`,
+      actorUserId: advisorUserId,
+      actorRole: caller.role,
+      targetType: 'group',
+      targetId: dto.groupId,
+      metadata: {
+        evaluationId: evaluation.evaluationId,
+        sprintId: dto.sprintId,
+        deliverableId: dto.deliverableId,
+        evaluationType: dto.evaluationType,
+        rubricId: rubric.rubricId,
+        averageScore,
+        grades: rubricGrades,
+      },
     });
 
     return this.toResponseDto(evaluation);

--- a/backend/src/submissions/submissions.controller.spec.ts
+++ b/backend/src/submissions/submissions.controller.spec.ts
@@ -7,6 +7,7 @@ import {
 } from './submissions.controller';
 import { SubmissionsService } from './submissions.service';
 import { Role } from '../auth/enums/role.enum'; 
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 
 describe('SubmissionsController', () => {
   let controller: SubmissionsController;
@@ -35,6 +36,10 @@ describe('SubmissionsController', () => {
         {
           provide: SubmissionsService,
           useValue: mockSubmissionsService,
+        },
+        {
+          provide: ActivityLogsService,
+          useValue: { create: jest.fn() },
         },
       ],
     }).compile();
@@ -89,7 +94,7 @@ describe('SubmissionsController', () => {
         req.user,
         dto.groupId,
       );
-      expect(service.createSubmission).toHaveBeenCalledWith(dto);
+      expect(service.createSubmission).toHaveBeenCalledWith(dto, req.user.role);
       expect(result).toEqual(created);
     });
 

--- a/backend/src/submissions/submissions.controller.ts
+++ b/backend/src/submissions/submissions.controller.ts
@@ -34,6 +34,7 @@ import { GroupMemberGuard } from '../auth/guards/group-member.guard';
 import { JurySubmissionResponseDto } from './dto/jury-submission-response.dto';
 import { AddCommentDto } from './dto/add-comment.dto';
 import { CreateRevisionRequestDto } from './dto/create-revision-request.dto';
+import { ActivityLogsService } from '../activity-logs/activity-logs.service';
 export const MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024;
 export const ALLOWED_UPLOAD_EXTENSIONS_REGEX =
   /\.(pdf|doc|docx|png|jpg|jpeg|md)$/i;
@@ -68,7 +69,10 @@ export function submissionsFileFilter(
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('submissions')
 export class SubmissionsController {
-  constructor(private readonly submissionsService: SubmissionsService) {}
+  constructor(
+    private readonly submissionsService: SubmissionsService,
+    private readonly activityLogsService: ActivityLogsService,
+  ) {}
 
   private validateObjectIdFormat(value: string, fieldName = 'ID') {
     if (!value.match(/^[0-9a-fA-F]{24}$/)) {
@@ -88,7 +92,9 @@ export class SubmissionsController {
 
   @Get('me')
   @Roles(Role.Student, Role.TeamLeader)
-  @ApiOperation({ summary: 'Get submissions for current student or team leader user' })
+  @ApiOperation({
+    summary: 'Get submissions for current student or team leader user',
+  })
   async getMySubmissions(@Req() req: Request & { user: any }) {
     const userGroupId = req.user.groupId;
 
@@ -118,7 +124,24 @@ export class SubmissionsController {
       req.user,
       createSubmissionDto.groupId,
     );
-    return this.submissionsService.createSubmission(createSubmissionDto, req.user.role);
+    const created = await this.submissionsService.createSubmission(
+      createSubmissionDto,
+      req.user.role,
+    );
+    await this.activityLogsService.create({
+      eventType: 'SUBMISSION_CREATED',
+      summary: 'Submission created',
+      actorUserId: req.user?.userId,
+      actorRole: req.user?.role,
+      targetType: 'submission',
+      targetId: created._id?.toString?.(),
+      metadata: {
+        groupId: createSubmissionDto.groupId,
+        phaseId: createSubmissionDto.phaseId,
+        type: createSubmissionDto.type,
+      },
+    });
+    return created;
   }
 
   @Get(':submissionId/completeness')
@@ -163,15 +186,35 @@ export class SubmissionsController {
     this.validateUploadedFile(file);
     const validatedFile = file!;
 
-    return this.submissionsService.uploadDocument(
+    const uploaded = await this.submissionsService.uploadDocument(
       submissionId,
       validatedFile,
       req.submission,
     );
+    await this.activityLogsService.create({
+      eventType: 'SUBMISSION_DOCUMENT_UPLOADED',
+      summary: 'Submission document uploaded',
+      actorUserId: req.user?.userId,
+      actorRole: req.user?.role,
+      targetType: 'submission',
+      targetId: submissionId,
+      metadata: {
+        originalName: validatedFile.originalname,
+        mimeType: validatedFile.mimetype,
+        size: validatedFile.size,
+      },
+    });
+    return uploaded;
   }
 
   @Get(':submissionId/documents/:documentIndex')
-  @Roles(Role.Student, Role.TeamLeader, Role.Professor, Role.Coordinator, Role.Admin)
+  @Roles(
+    Role.Student,
+    Role.TeamLeader,
+    Role.Professor,
+    Role.Coordinator,
+    Role.Admin,
+  )
   @ApiOperation({ summary: 'Download a submission document by index' })
   async downloadDocument(
     @Req() req: Request & { user: any; submission?: any },
@@ -190,13 +233,19 @@ export class SubmissionsController {
     if (userRole === Role.Student || userRole === Role.TeamLeader) {
       const submission = await this.submissionsService.findById(submissionId);
       if (!submission) throw new ForbiddenException('Submission not found.');
-      await this.submissionsService.assertAuthorizedGroupMember(req.user, submission.groupId);
+      await this.submissionsService.assertAuthorizedGroupMember(
+        req.user,
+        submission.groupId,
+      );
     }
     // Professor: must be the advisor or a jury member of the group
     if (userRole === Role.Professor) {
       const submission = await this.submissionsService.findById(submissionId);
       if (!submission) throw new ForbiddenException('Submission not found.');
-      await this.submissionsService.assertProfessorCanAccessSubmission(submission, req.user.userId);
+      await this.submissionsService.assertProfessorCanAccessSubmission(
+        submission,
+        req.user.userId,
+      );
     }
     // Coordinator, Admin: unrestricted
 
@@ -233,10 +282,11 @@ export class SubmissionsController {
           'Only professors can filter submissions by committee.',
         );
       }
-      const groupIds = await this.submissionsService.getCommitteeSubmissionGroupIds(
-        committeeId,
-        req.user.userId,
-      );
+      const groupIds =
+        await this.submissionsService.getCommitteeSubmissionGroupIds(
+          committeeId,
+          req.user.userId,
+        );
       return this.submissionsService.findAll(undefined, groupIds);
     }
 
@@ -252,7 +302,10 @@ export class SubmissionsController {
       if (groupId) {
         // Validate professor is authorized for the requested group
         const stub = { groupId } as any;
-        await this.submissionsService.assertProfessorCanAccessSubmission(stub, req.user.userId);
+        await this.submissionsService.assertProfessorCanAccessSubmission(
+          stub,
+          req.user.userId,
+        );
         return this.submissionsService.findAll(groupId);
       }
       // No groupId filter: return all submissions the professor can access
@@ -263,7 +316,13 @@ export class SubmissionsController {
   }
 
   @Get(':id')
-  @Roles(Role.Student, Role.TeamLeader, Role.Professor, Role.Coordinator, Role.Admin) 
+  @Roles(
+    Role.Student,
+    Role.TeamLeader,
+    Role.Professor,
+    Role.Coordinator,
+    Role.Admin,
+  )
   @ApiOperation({ summary: 'Get submission details by ID' })
   async findOne(@Req() req: Request & { user: any }, @Param('id') id: string) {
     this.validateObjectIdFormat(id);
@@ -313,7 +372,6 @@ export class SubmissionsController {
     this.validateObjectIdFormat(submissionId, 'submissionId');
     return this.submissionsService.getSubmissionForJury(userId, submissionId);
   }
-  
 
   @Post(':submissionId/comments')
   @Roles(Role.Professor)
@@ -326,7 +384,23 @@ export class SubmissionsController {
   ) {
     this.validateObjectIdFormat(submissionId, 'submissionId');
     const userId = req.user.userId || req.user.sub || req.user._id;
-    return this.submissionsService.addComment(userId, submissionId, dto);
+    const comment = await this.submissionsService.addComment(
+      userId,
+      submissionId,
+      dto,
+    );
+    await this.activityLogsService.create({
+      eventType: 'SUBMISSION_COMMENT_ADDED',
+      summary: 'Committee review comment added',
+      actorUserId: userId,
+      actorRole: req.user?.role,
+      targetType: 'submission',
+      targetId: submissionId,
+      metadata: {
+        commentLength: dto.commentText?.length ?? 0,
+      },
+    });
+    return comment;
   }
 
   @Get(':submissionId/comments')
@@ -352,8 +426,22 @@ export class SubmissionsController {
   ) {
     this.validateObjectIdFormat(submissionId, 'submissionId');
     const userId = req.user.userId || req.user.sub || req.user._id;
-    return this.submissionsService.createRevisionRequest(userId, submissionId, dto);
+    const revisionRequest = await this.submissionsService.createRevisionRequest(
+      userId,
+      submissionId,
+      dto,
+    );
+    await this.activityLogsService.create({
+      eventType: 'SUBMISSION_REVISION_REQUESTED',
+      summary: 'Revision requested for submission',
+      actorUserId: userId,
+      actorRole: req.user?.role,
+      targetType: 'submission',
+      targetId: submissionId,
+      metadata: {
+        revisionDueDatetime: dto.revisionDueDatetime,
+      },
+    });
+    return revisionRequest;
   }
-
-
 }

--- a/backend/src/submissions/submissions.module.ts
+++ b/backend/src/submissions/submissions.module.ts
@@ -8,6 +8,7 @@ import { User, UserSchema } from '../users/data/user.schema';
 import { GroupMemberGuard } from '../auth/guards/group-member.guard';
 import { Group, GroupSchema } from '../groups/group.entity';
 import { Committee, CommitteeSchema } from '../committees/schemas/committee.schema';
+import { ActivityLogsModule } from '../activity-logs/activity-logs.module';
 
 
 @Module({
@@ -19,6 +20,7 @@ import { Committee, CommitteeSchema } from '../committees/schemas/committee.sche
       { name: Committee.name, schema: CommitteeSchema },
     ]),
     PhasesModule,
+    ActivityLogsModule,
   ],
   controllers: [SubmissionsController],
   providers: [SubmissionsService, GroupMemberGuard],

--- a/frontend/src/pages/admin/ActivityPage.jsx
+++ b/frontend/src/pages/admin/ActivityPage.jsx
@@ -1,3 +1,4 @@
+// frontend/src/pages/admin/ActivityPage.jsx
 import { useState, useEffect } from 'react'
 import apiClient from '../../utils/apiClient'
 import apiConfig from '../../config/api'
@@ -15,20 +16,58 @@ function ActivityPage() {
   }, [])
 
   useEffect(() => {
-    const filtered = logs.filter(
-      (log) =>
-        log.user.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        log.action.toLowerCase().includes(searchTerm.toLowerCase())
-    )
+    const normalizedSearch = searchTerm.toLowerCase()
+    const filtered = logs.filter((log) => {
+      const userText = String(log.user ?? '').toLowerCase()
+      const subText = String(log.userSubtext ?? '').toLowerCase()
+      const actionText = String(log.action ?? '').toLowerCase()
+      const typeText = String(log.eventType ?? '').toLowerCase()
+      return (
+        userText.includes(normalizedSearch) ||
+        subText.includes(normalizedSearch) ||
+        actionText.includes(normalizedSearch) ||
+        typeText.includes(normalizedSearch)
+      )
+    })
     setFilteredLogs(filtered)
   }, [logs, searchTerm])
+
+  const actorDisplay = (log) => {
+    const name = log.actorName?.trim?.()
+    const email = log.actorEmail?.trim?.()
+    if (name) return name
+    if (email) return email
+    if (log.user && log.user !== log.actorUserId) return log.user
+    return log.actorUserId ?? 'System'
+  }
+
+  const mapLog = (log) => ({
+    id: log.id ?? log._id ?? `${log.timestamp ?? ''}-${log.eventType ?? ''}`,
+    timestamp: log.timestamp,
+    user: actorDisplay(log),
+    userSubtext:
+      log.actorName && log.actorEmail
+        ? log.actorEmail
+        : log.actorUserId && (log.actorName || log.actorEmail)
+          ? log.actorUserId
+          : null,
+    action: log.action ?? log.summary ?? log.eventType ?? 'Unknown action',
+    eventType: log.eventType ?? null,
+  })
 
   const fetchActivityLogs = async () => {
     try {
       setLoading(true)
       const response = await apiClient.get(apiConfig.endpoints.activityLogs)
-      setLogs(response.data)
-      setFilteredLogs(response.data)
+      const payload = response?.data
+      const rawLogs = Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload?.data)
+          ? payload.data
+          : []
+      const normalizedLogs = rawLogs.map(mapLog)
+      setLogs(normalizedLogs)
+      setFilteredLogs(normalizedLogs)
     } catch (err) {
       setError('Failed to fetch activity logs')
       console.error(err)
@@ -85,15 +124,24 @@ function ActivityPage() {
               <tr>
                 <th className="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-500">Timestamp</th>
                 <th className="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-500">User</th>
-                <th className="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-500">Action Type</th>
+                <th className="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-500">Event</th>
+                <th className="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-500">Summary</th>
               </tr>
             </thead>
             <tbody>
-              {filteredLogs.map((log, index) => (
-                <tr key={index} className="border-t border-[#1e293b] hover:bg-white/[0.02]">
-                  <td className="px-4 py-3 text-slate-300 text-sm">{formatTimestamp(log.timestamp)}</td>
-                  <td className="px-4 py-3 text-slate-300 text-sm">{log.user}</td>
-                  <td className="px-4 py-3 text-slate-300 text-sm">{log.action}</td>
+              {filteredLogs.map((log) => (
+                <tr key={log.id} className="border-t border-[#1e293b] hover:bg-white/[0.02]">
+                  <td className="px-4 py-3 text-slate-300 text-sm align-top">{formatTimestamp(log.timestamp)}</td>
+                  <td className="px-4 py-3 text-slate-300 text-sm align-top">
+                    <div className="font-medium text-slate-200">{log.user}</div>
+                    {log.userSubtext ? (
+                      <div className="text-[11px] text-slate-500 mt-0.5 font-mono truncate max-w-[220px]" title={log.userSubtext}>
+                        {log.userSubtext}
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3 text-slate-400 text-xs font-mono align-top">{log.eventType ?? '—'}</td>
+                  <td className="px-4 py-3 text-slate-300 text-sm align-top">{log.action}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary
This PR implements **sitewide backend activity logging** via `ActivityLogsService` integrations (auth, admin, grades, invites, submissions, reviews, sprint evaluations, and related modules), adds **actor enrichment** (`actorName`, `actorEmail`) when listing logs, introduces **`safeCreate`** for non-blocking audit writes where appropriate, and updates the **Admin Activity page** to handle the **paginated API response** and display **readable actors** plus improved search/normalization.

Closes #326 

---

## Type of Change
- [x] Feature (new endpoint or business logic)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Configuration / infrastructure
- [ ] Background job / scheduled task
- [x] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change

**Backend:**
- Controller(s): **`admin.controller`** (audit after admin mutations); **`invites.controller`**, **`submissions.controller`**, plus other controllers wired per branch
- Use case(s) / service(s): **`activity-logs.service`** (`attachActorProfiles`, `safeCreate`); **`auth.service`** (auth lifecycle audit); **`grades.service`**; **`reviews.service`**; **`sprint-evaluations.service`**; **`admin`** flows delegating logging
- Repository / DB layer: **`ActivityLog`** writes; **`User`** reads for enrichment
- Schema / migration: **None** — additive optional fields on responses only

**Frontend:**
- Component(s): **`frontend/src/pages/admin/ActivityPage.jsx`** — pagination payload unwrap, **`actorName`/`actorEmail`/`summary`/`eventType`** mapping, search/filter UX
- API client / DTO: Existing **`activityLogs`** endpoint usage; aligns with **`PaginatedActivityLogsDto`**

**Infrastructure / Config:**
- Module imports: **`ActivityLogsModule`** added to **`auth`**, **`grades`**, **`invites`**, **`submissions`**, **`reviews`**, **`sprint-evaluations`**, etc., as in branch

---

## API Contract Alignment

| Field | Value |
|---|---|
| Endpoint | `GET /admin/activity` (plus existing mutation endpoints emitting logs) |
| OperationId | `getAdminActivityLogs` |
| OpenAPI file | `backend/swagger.json` (+ `docs/api/api-specs/*` if applicable) |
| Spec updated in this PR | **Yes** (if `ActivityLogDto` / Swagger regenerated in-repo) |

- [ ] Response shape matches **`PaginatedActivityLogsDto`** / **`ActivityLogDto`** including **`actorName`**, **`actorEmail`**
- [ ] Existing status codes unchanged for **`GET /admin/activity`**
- [ ] Audit metadata does not expose secrets (**no tokens/passwords** in client-visible payloads beyond existing patterns)

---

## Clean Architecture Checklist

**Infrastructure / API layer:**
- [x] Auth + roles unchanged for listing activity logs
- [ ] Controllers that call **`activityLogsService.create`** execute logging **after** successful domain work **or** use **`safeCreate`** where non-blocking semantics are intentional

**Application / Use Case layer:**
- [x] **`safeCreate`** does not throw to callers on persistence failure (**warn** logged)
- [x] List endpoint enriches DTOs server-side (**no** client-sent actor name spoofing)

**Domain / Repository layer:**
- [x] User enrichment query scoped to **`$in`** of actor IDs from **current page** only

---

## Test Evidence

**Unit tests:**
- [x] `activity-logs.service.spec` — mocks `User` model
- [x] `auth.service.spec`, `grades.service.spec`, **`admin.controller.spec`**, **`invites.controller.spec`**, **`submissions.controller.spec`**, related specs updated

**Integration / E2E tests:**
- [ ] Optionally `admin-activity.e2e-spec` or equivalent **if touched**

**Test file locations:**
- Unit: `backend/src/**/*/*.spec.ts` (see changed files list in PR Files)

**Test run output:**
```text
PS F:\git\schoolProject\senior-app-5\backend> npx jest activity-logs/activity-logs.service.spec.ts
 PASS  src/activity-logs/activity-logs.service.spec.ts
  ActivityLogsService
    redactMetadata                                                                                                    
      √ redacts sensitive keys recursively, case-insensitive (13 ms)                                                  
    create                                                                                                            
      √ redacts metadata before persisting (3 ms)                                                                     
      √ coerces actorUserId string to ObjectId (3 ms)                                                                 
    findPaginated                                                                                                     
      √ paginates with deterministic sort and returns total (6 ms)                                                    
      √ combines filters: eventType, actorUserId, date range, search (7 ms)
      √ throws BadRequestException when from > to (2 ms)                                                              
                                                                                                                      
Test Suites: 1 passed, 1 total                                                                                        
Tests:       6 passed, 6 total                                                                                        
Snapshots:   0 total
Time:        1.289 s
Ran all test suites matching activity-logs/activity-logs.service.spec.ts.
PS F:\git\schoolProject\senior-app-5\backend> npx jest admin/admin.controller.spec.ts -t "getActivityLogs"
 PASS  src/admin/admin.controller.spec.ts
  AdminController - RBAC Matrix Validation
    √ should restrict getActivityLogs to Admin and Coordinator (15 ms)                                                
    √ getActivityLogs should delegate to AdminService with the parsed query (5 ms)                                    
    ○ skipped should restrict moveStudentToGroup to Admin and Coordinator                                             
    ○ skipped should restrict getAdvisorValidation to Admin and Coordinator                                           
    ○ skipped should restrict executeSanitization to Admin and Coordinator                                            
                                                                                                                      
Test Suites: 1 passed, 1 total                                                                                        
Tests:       3 skipped, 2 passed, 5 total                                                                             
Snapshots:   0 total
Time:        1.52 s, estimated 2 s
Ran all test suites matching admin/admin.controller.spec.ts with tests matching "getActivityLogs".
PS F:\git\schoolProject\senior-app-5\backend> npm run test:e2e -- admin-activity.e2e-spec.ts

> backend@0.0.1 test:e2e
> jest --config ./test/jest-e2e.json admin-activity.e2e-spec.ts

 PASS  test/admin-activity.e2e-spec.ts
  Admin Activity Logs (e2e)
    √ GET /admin/activity returns 401 without bearer token (173 ms)                                                   
    √ GET /admin/activity returns 403 for student (28 ms)                                                             
    √ GET /admin/activity returns 200 and paginated payload for Admin (22 ms)                                         
    √ GET /admin/activity returns 200 for Coordinator (15 ms)                                                         
    √ GET /admin/activity returns 400 for invalid pagination (18 ms)                                                  
    √ GET /admin/activity returns 400 for malformed date (16 ms)                                                      
                                                                                                                      
Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        1.965 s, estimated 2 s
Ran all test suites matching admin-activity.e2e-spec.ts.