### PR TITLE
Fix/grading scope

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -243,7 +243,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2182,7 +2181,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2230,7 +2228,6 @@
       "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2326,7 +2323,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
       "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2756,7 +2752,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2786,7 +2781,6 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2902,7 +2896,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3103,7 +3096,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3811,7 +3803,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3870,7 +3861,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4135,7 +4125,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4408,7 +4397,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4695,15 +4683,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5675,7 +5661,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5736,7 +5721,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5969,7 +5953,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7396,7 +7379,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8970,7 +8952,6 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.4.1.tgz",
       "integrity": "sha512-4rFBWa+/wdBQSfvnOPJBpiSG6UCEbhSQh865dEdaH9Y8WfHBUC+I2XT28dp0IBIGrEwmh+gzrgZgea5PbmrHWA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "kareem": "3.2.0",
         "mongodb": "~7.1",
@@ -9471,7 +9452,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9717,7 +9697,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9936,8 +9915,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/repeating": {
       "version": "2.0.1",
@@ -10145,7 +10123,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11009,7 +10986,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11385,7 +11361,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11568,7 +11543,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11955,7 +11929,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -12025,7 +11998,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/backend/src/committees/committees.controller.ts
+++ b/backend/src/committees/committees.controller.ts
@@ -64,6 +64,26 @@ export class CommitteesController {
 
   @ApiBearerAuth('access-token')
   @ApiOperation({
+    operationId: 'getMyGradableGroups',
+    summary:
+      'Groups the caller can grade deliverables for (advisor or jury membership in a committee).',
+  })
+  @ApiOkResponse({ description: 'Gradable groups returned.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(Role.Professor, Role.Coordinator, Role.Admin)
+  @Get('me/gradable-groups')
+  @HttpCode(HttpStatus.OK)
+  async getMyGradableGroups(@Request() req: RequestWithUser) {
+    const userId = req.user.userId ?? req.user.sub ?? req.user._id;
+    if (!userId) {
+      return { data: [] };
+    }
+    return this.committeesService.getMyGradableGroups(userId);
+  }
+
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
     operationId: 'listCommittees',
     summary: 'List committees with pagination (COORDINATOR only)',
   })

--- a/backend/src/committees/committees.service.ts
+++ b/backend/src/committees/committees.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   HttpException,
   Injectable,
   InternalServerErrorException,
@@ -1019,11 +1020,15 @@ export class CommitteesService {
       }
 
       type AdvisorEntry = { advisorId?: string; userId?: string; advisorUserId?: string };
+      type JuryEntry = { userId?: string };
       const advisorLinked = ((committee.advisors as AdvisorEntry[]) ?? []).some(
         (a) => a.advisorId === advisorUserId || a.userId === advisorUserId || a.advisorUserId === advisorUserId,
       );
-      if (!advisorLinked) {
-        throw new NotFoundException(`Advisor '${advisorUserId}' is not a member of committee '${committeeId}'.`);
+      const juryLinked = ((committee.jury as JuryEntry[]) ?? []).some(
+        (j) => j.userId === advisorUserId,
+      );
+      if (!advisorLinked && !juryLinked) {
+        throw new NotFoundException(`User '${advisorUserId}' is not a member of committee '${committeeId}' (neither advisor nor jury).`);
       }
 
       const committeeGroups = (committee.groups as any[]) ?? [];
@@ -1035,6 +1040,9 @@ export class CommitteesService {
 
       const advisorMap = new Map<string, string | null>(
         groupDocs.map((g) => [g.groupId, g.assignedAdvisorId ?? null]),
+      );
+      const groupNameMap = new Map<string, string | null>(
+        groupDocs.map((g) => [g.groupId, (g as any).groupName ?? null]),
       );
 
       const page = query.page ?? 1;
@@ -1049,6 +1057,7 @@ export class CommitteesService {
           const isOwnGroup = primaryAdvisor === advisorUserId;
           return {
             groupId: g.groupId as string,
+            groupName: groupNameMap.get(g.groupId as string) ?? null,
             assignedAt: g.assignedAt as Date,
             isOwnGroup,
             originalAdvisorUserId: isOwnGroup ? null : primaryAdvisor,
@@ -1061,6 +1070,129 @@ export class CommitteesService {
       if (error instanceof NotFoundException) throw error;
       this.logger.error({ event: 'advisor_grading_scope_failed', committeeId, advisorUserId, correlationId, error: (error as Error).message });
       throw new InternalServerErrorException('Failed to retrieve advisor grading scope due to an unexpected error.');
+    }
+  }
+
+  /**
+   * Returns every group the caller may grade deliverables for, derived from
+   * committee membership (advisor or jury). Sprint evaluations remain
+   * advisor-only and are checked elsewhere.
+   */
+  async getMyGradableGroups(userId: string): Promise<{
+    data: Array<{
+      groupId: string;
+      groupName: string | null;
+      committeeId: string;
+      role: 'advisor' | 'jury';
+      isOwnGroup: boolean;
+    }>;
+  }> {
+    type AdvisorEntry = { advisorId?: string; userId?: string; advisorUserId?: string };
+    type JuryEntry = { userId?: string };
+
+    // Find committees the caller belongs to as advisor or jury.
+    const committees = await this.committeeModel
+      .find({
+        $or: [
+          { 'advisors.advisorId': userId },
+          { 'advisors.userId': userId },
+          { 'advisors.advisorUserId': userId },
+          { 'jury.userId': userId },
+        ],
+      })
+      .lean()
+      .exec();
+
+    if (committees.length === 0) return { data: [] };
+
+    const allGroupIds = [
+      ...new Set(
+        committees.flatMap((c) =>
+          ((c.groups as { groupId: string }[]) ?? []).map((g) => g.groupId),
+        ),
+      ),
+    ];
+
+    const groupDocs = allGroupIds.length > 0
+      ? await this.groupModel
+          .find({ groupId: { $in: allGroupIds } })
+          .select('groupId groupName assignedAdvisorId')
+          .lean()
+          .exec()
+      : [];
+    const groupMap = new Map(
+      (groupDocs as any[]).map((g) => [
+        g.groupId,
+        { groupName: g.groupName ?? null, assignedAdvisorId: g.assignedAdvisorId ?? null },
+      ]),
+    );
+
+    const data: Array<{
+      groupId: string;
+      groupName: string | null;
+      committeeId: string;
+      role: 'advisor' | 'jury';
+      isOwnGroup: boolean;
+    }> = [];
+
+    // Deduplicate by (groupId, committeeId) — caller may belong to multiple
+    // committees, but each (group, committee) edge is unique.
+    const seen = new Set<string>();
+    for (const c of committees) {
+      const callerIsAdvisorInThisCommittee = ((c.advisors as AdvisorEntry[]) ?? []).some(
+        (a) => a.advisorId === userId || a.userId === userId || a.advisorUserId === userId,
+      );
+      const callerIsJuryInThisCommittee = ((c.jury as JuryEntry[]) ?? []).some(
+        (j) => j.userId === userId,
+      );
+
+      // Caller's role in this committee — advisor takes precedence over jury
+      const role: 'advisor' | 'jury' = callerIsAdvisorInThisCommittee
+        ? 'advisor'
+        : callerIsJuryInThisCommittee
+        ? 'jury'
+        : 'advisor';
+
+      for (const g of (c.groups as { groupId: string }[]) ?? []) {
+        const key = `${g.groupId}::${c.id}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const meta = groupMap.get(g.groupId);
+        data.push({
+          groupId: g.groupId,
+          groupName: meta?.groupName ?? null,
+          committeeId: c.id as string,
+          role,
+          isOwnGroup: meta?.assignedAdvisorId === userId,
+        });
+      }
+    }
+
+    return { data };
+  }
+
+  /**
+   * Throws ForbiddenException if the caller is not allowed to record a
+   * deliverable evaluation for this group. Allowed when the caller belongs
+   * (advisor or jury) to ANY committee that includes this group.
+   */
+  async assertCanGradeDeliverable(groupId: string, userId: string): Promise<void> {
+    const committee = await this.committeeModel
+      .findOne({
+        'groups.groupId': groupId,
+        $or: [
+          { 'advisors.advisorId': userId },
+          { 'advisors.userId': userId },
+          { 'advisors.advisorUserId': userId },
+          { 'jury.userId': userId },
+        ],
+      })
+      .lean()
+      .exec();
+    if (!committee) {
+      throw new ForbiddenException(
+        `You are not on a committee for group '${groupId}', so you cannot record a deliverable evaluation.`,
+      );
     }
   }
 }

--- a/backend/src/committees/dto/advisor-grading-scope-page.dto.ts
+++ b/backend/src/committees/dto/advisor-grading-scope-page.dto.ts
@@ -4,6 +4,12 @@ export class AdvisorGradingScopeItemDto {
   @ApiProperty({ description: 'ID of the group this advisor must grade' })
   groupId!: string;
 
+  @ApiPropertyOptional({
+    description: 'Display name of the group (joined from Group collection).',
+    nullable: true,
+  })
+  groupName?: string | null;
+
   @ApiProperty({ type: String, format: 'date-time', description: 'When the group was assigned to the committee' })
   assignedAt!: Date;
 

--- a/backend/src/grades/grades.controller.ts
+++ b/backend/src/grades/grades.controller.ts
@@ -126,7 +126,11 @@ export class GradesController {
     @Req() req: RequestWithUser,
   ): Promise<DeliverableEvaluationResponseDto> {
     const gradedBy = this.getRequiredJwtUserId(req);
-    return this.gradesService.recordDeliverableEvaluation(dto, gradedBy);
+    return this.gradesService.recordDeliverableEvaluation(
+      dto,
+      gradedBy,
+      req.user.role,
+    );
   }
 
   @ApiOperation({

--- a/backend/src/grades/grades.service.ts
+++ b/backend/src/grades/grades.service.ts
@@ -256,6 +256,7 @@ export class GradesService {
   async recordDeliverableEvaluation(
     dto: CreateDeliverableEvaluationDto,
     gradedBy: string,
+    callerRole?: string,
   ): Promise<DeliverableEvaluationResponseDto> {
     const deliverable = await this.deliverableModel
       .findOne({ deliverableId: dto.deliverableId })
@@ -277,9 +278,36 @@ export class GradesService {
       );
     }
 
+    // Coordinators/Admins bypass committee membership; Professors must be on
+    // a committee that includes this group (advisor or jury role).
+    const callerIsStaff =
+      callerRole === Role.Coordinator || callerRole === Role.Admin;
+    if (!callerIsStaff) {
+      const committee = await this.committeeModel
+        .findOne({
+          'groups.groupId': dto.groupId,
+          $or: [
+            { 'advisors.advisorId': gradedBy },
+            { 'advisors.userId': gradedBy },
+            { 'advisors.advisorUserId': gradedBy },
+            { 'jury.userId': gradedBy },
+          ],
+        })
+        .lean()
+        .exec();
+      if (!committee) {
+        throw new BadRequestException(
+          `You are not on a committee for group '${dto.groupId}'. Only the group's committee advisors or jury members can record a deliverable evaluation.`,
+        );
+      }
+    }
+
+    // Upsert keyed by (groupId, deliverableId, gradedBy) so each committee
+    // member (advisor or jury) keeps their own grade. The pipeline averages
+    // these in step 8.4.
     const upserted = await this.deliverableEvaluationModel
       .findOneAndUpdate(
-        { groupId: dto.groupId, deliverableId: dto.deliverableId },
+        { groupId: dto.groupId, deliverableId: dto.deliverableId, gradedBy },
         {
           $set: {
             deliverableGrade: dto.deliverableGrade,
@@ -507,9 +535,19 @@ export class GradesService {
       );
     }
 
-    const deliverableIds = deliverableEvals.map((e) => e.deliverableId);
+    // Group evaluations per deliverable so we can average across all graders
+    // (the group's primary advisor + every committee jury/advisor that
+    // submitted a grade for the same deliverable).
+    const evalsByDeliverable = new Map<string, typeof deliverableEvals>();
+    for (const e of deliverableEvals) {
+      const list = evalsByDeliverable.get(e.deliverableId) ?? [];
+      list.push(e);
+      evalsByDeliverable.set(e.deliverableId, list);
+    }
+
+    const uniqueDeliverableIds = [...evalsByDeliverable.keys()];
     const deliverables = await this.deliverableModel
-      .find({ deliverableId: { $in: deliverableIds } })
+      .find({ deliverableId: { $in: uniqueDeliverableIds } })
       .lean()
       .exec();
 
@@ -517,7 +555,7 @@ export class GradesService {
       deliverables.map((d) => [d.deliverableId, d]),
     );
 
-    for (const deliverableId of deliverableIds) {
+    for (const deliverableId of uniqueDeliverableIds) {
       if (!deliverableConfigMap.has(deliverableId)) {
         throw new UnprocessableEntityException(
           `Deliverable config not found for deliverableId=${deliverableId}.`,
@@ -528,23 +566,49 @@ export class GradesService {
     const scaledDeliverableGrades: ScaledDeliverableGradeDto[] = [];
     let teamGradeRaw = 0;
 
-    for (const deliverableEval of deliverableEvals) {
-      const deliverable = deliverableConfigMap.get(
-        deliverableEval.deliverableId,
-      )!;
+    for (const deliverableId of uniqueDeliverableIds) {
+      const deliverable = deliverableConfigMap.get(deliverableId)!;
+      const evalsForThisDeliverable = evalsByDeliverable.get(deliverableId)!;
+
+      // Average the rawGrade across every committee member who graded this
+      // deliverable. Order in the array doesn't matter since we average.
+      const sum = evalsForThisDeliverable.reduce(
+        (acc, e) => acc + (e.rawGrade ?? 0),
+        0,
+      );
+      const avgRawGrade = sum / evalsForThisDeliverable.length;
+
       // Deliverables with no sprint mapping are not penalised — full scalar.
-      const teamScalar =
-        deliverableScalarMap.get(deliverableEval.deliverableId) ?? 1.0;
+      const teamScalar = deliverableScalarMap.get(deliverableId) ?? 1.0;
       const scaledGrade =
-        deliverableEval.rawGrade *
+        avgRawGrade *
         teamScalar *
         (deliverable.deliverablePercentage / 100);
 
       teamGradeRaw += scaledGrade;
 
+      this.logger.log(
+        JSON.stringify({
+          event: 'step_8_4_deliverable_averaged',
+          groupId,
+          deliverableId,
+          graderCount: evalsForThisDeliverable.length,
+          rawGrades: evalsForThisDeliverable.map((e) => ({
+            gradedBy: e.gradedBy,
+            rawGrade: e.rawGrade,
+            deliverableGrade: e.deliverableGrade,
+          })),
+          avgRawGrade: Number(avgRawGrade.toFixed(2)),
+          teamScalar,
+          deliverablePercentage: deliverable.deliverablePercentage,
+          scaledGrade: Number(scaledGrade.toFixed(2)),
+          correlationId: correlationId ?? null,
+        }),
+      );
+
       scaledDeliverableGrades.push({
-        deliverableId: deliverableEval.deliverableId,
-        rawGrade: deliverableEval.rawGrade,
+        deliverableId,
+        rawGrade: Number(avgRawGrade.toFixed(2)),
         teamScalar,
         deliverablePercentage: deliverable.deliverablePercentage,
         scaledGrade: Number(scaledGrade.toFixed(2)),
@@ -709,25 +773,57 @@ export class GradesService {
         let individualAllowanceRatio: number;
         let branchUsed: string;
 
-        if (deliverableRatios && deliverableRatios.size > 0 && scaledDeliverableGrades.length > 0) {
-          // student_final = SUM( scaled_deliverable_grade[d] × individual_ratio[d] ) / teamGrade
-          // Then express as a ratio relative to teamGrade so finalGrade = teamGrade × ratio is correct
+        // The per-deliverable computation is "informed" only when at least
+        // one (deliverableId, sprintId) edge has a non-zero weight AND the
+        // student has a sprint-ratio entry for that same sprintId. If
+        // informed, trust the result (a true 0 means the student really did
+        // 0 work in mapped sprints). If uninformed (sprintId mismatch
+        // between SprintConfig.deliverableMappings and StoryPointRecord),
+        // fall back to the student's aggregate story-point ratio.
+        let perDeliverableInformed = false;
+        let perDeliverableRatio = 0;
+        if (
+          deliverableRatios &&
+          deliverableRatios.size > 0 &&
+          scaledDeliverableGrades.length > 0
+        ) {
+          for (const [deliverableId, sprintIds] of deliverableSprintMap) {
+            for (const sprintId of sprintIds) {
+              const weight =
+                sprintDeliverableWeights.get(sprintId)?.get(deliverableId) ?? 0;
+              const hasStudentRatio =
+                sprintRatioMap.get(sprintId)?.has(studentId) ?? false;
+              if (weight > 0 && hasStudentRatio) {
+                perDeliverableInformed = true;
+                break;
+              }
+            }
+            if (perDeliverableInformed) break;
+          }
+
           let weightedStudentGrade = 0;
           for (const sdg of scaledDeliverableGrades) {
             const ratio = deliverableRatios.get(sdg.deliverableId) ?? 0;
             weightedStudentGrade += sdg.scaledGrade * ratio;
           }
-          individualAllowanceRatio = teamGrade > 0
+          perDeliverableRatio = teamGrade > 0
             ? Math.min(1, weightedStudentGrade / teamGrade)
             : 0;
+        }
+
+        if (perDeliverableInformed) {
+          // Trust the per-deliverable result, even if it's 0 — the student
+          // genuinely had no completion in any mapped sprint.
+          individualAllowanceRatio = perDeliverableRatio;
           branchUsed = 'per_deliverable_weighted';
+        } else if (totals.target > 0) {
+          // Mappings disconnected from this student's sprints; use the
+          // aggregate completion ratio as the best available signal.
+          individualAllowanceRatio = Math.min(1, totals.completed / totals.target);
+          branchUsed = 'aggregate_story_points';
         } else {
-          // Fallback: aggregate ratio across all sprints
-          // target === 0 means no story point data → treat as full participation (1.0)
-          individualAllowanceRatio =
-            totals.target > 0 ? Math.min(1, totals.completed / totals.target) : 1.0;
-          branchUsed =
-            totals.target > 0 ? 'aggregate_story_points' : 'no_story_points_full_participation';
+          individualAllowanceRatio = 1.0;
+          branchUsed = 'no_story_points_full_participation';
         }
 
         const finalGrade = Number(

--- a/backend/src/grades/schemas/deliverable-evaluation.schema.ts
+++ b/backend/src/grades/schemas/deliverable-evaluation.schema.ts
@@ -81,8 +81,12 @@ export class DeliverableEvaluation {
 export const DeliverableEvaluationSchema =
   SchemaFactory.createForClass(DeliverableEvaluation);
 
-// Unique: one grade per group per deliverable.
+// Unique: one grade per (group, deliverable, grader). Multiple committee
+// members (advisors + jury) each contribute their own evaluation; the grade
+// pipeline averages rawGrade across all graders per (group, deliverable).
 DeliverableEvaluationSchema.index(
-  { groupId: 1, deliverableId: 1 },
+  { groupId: 1, deliverableId: 1, gradedBy: 1 },
   { unique: true },
 );
+// Non-unique lookup index for the average computation in step 8.4.
+DeliverableEvaluationSchema.index({ groupId: 1, deliverableId: 1 });

--- a/backend/src/sprint-configs/dto/create-sprint-config.dto.ts
+++ b/backend/src/sprint-configs/dto/create-sprint-config.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
+  ArrayMinSize,
   IsArray,
   IsInt,
   IsOptional,
@@ -47,8 +48,14 @@ export class CreateSprintConfigDto {
   @Min(0)
   targetStoryPoints!: number;
 
-  @ApiProperty({ type: [DeliverableMappingDto], minItems: 0 })
+  @ApiProperty({
+    type: [DeliverableMappingDto],
+    minItems: 1,
+    description:
+      'At least one deliverable mapping is required so grade calculation can attribute this sprint to a deliverable.',
+  })
   @IsArray()
+  @ArrayMinSize(1, { message: 'At least one deliverableMapping is required.' })
   @ValidateNested({ each: true })
   @Type(() => DeliverableMappingDto)
   deliverableMappings!: DeliverableMappingDto[];

--- a/backend/src/sprint-evaluations/sprint-evaluations.service.ts
+++ b/backend/src/sprint-evaluations/sprint-evaluations.service.ts
@@ -111,7 +111,6 @@ export class SprintEvaluationsService {
       metadata: {
         evaluationId: evaluation.evaluationId,
         sprintId: dto.sprintId,
-        deliverableId: dto.deliverableId,
         evaluationType: dto.evaluationType,
         rubricId: rubric.rubricId,
         averageScore,

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -67,6 +67,7 @@ export const apiConfig = {
     committeeGroups: (committeeId) => `/committees/${committeeId}/groups`,
     committeeGroupById: (committeeId, groupId) => `/committees/${committeeId}/groups/${groupId}`,
     committeeAdvisorGradingScope: (committeeId, advisorUserId) => `/committees/${committeeId}/advisors/${advisorUserId}/groups`,
+    myGradableGroups: '/committees/me/gradable-groups',
     activityLogs: '/admin/activity',
     adminProfessors: '/auth/admin/professors',
     groupFinalGrade: (groupId) => `/groups/${groupId}/final-grade`,

--- a/frontend/src/pages/DeliverableGradingPage.jsx
+++ b/frontend/src/pages/DeliverableGradingPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { toast } from 'react-hot-toast';
 import { ChevronDown, ChevronRight, BookOpen, Package } from 'lucide-react';
 import apiClient from '../utils/apiClient';
+import apiConfig from '../config/api';
 import { PageHeader } from '../components/ui';
 
 const SOFT_GRADES = ['A', 'B', 'C', 'D', 'F'];
@@ -316,12 +317,16 @@ const DeliverableGradingPage = () => {
 
   useEffect(() => {
     const load = async () => {
-      const [reqRes, delRes] = await Promise.allSettled([
-        apiClient.get('/requests', { params: { status: 'APPROVED', limit: 100 } }),
-        apiClient.get('/deliverables', { params: { limit: 100 } }),
+      // Lists every group the caller can grade deliverables for — both
+      // groups they advise directly and groups they jury via committee
+      // membership. Sprint evaluations remain advisor-only and are gated
+      // server-side, not here.
+      const [groupsRes, delRes] = await Promise.allSettled([
+        apiClient.get(apiConfig.endpoints.myGradableGroups),
+        apiClient.get(apiConfig.endpoints.deliverables, { params: { limit: 100 } }),
       ]);
-      if (reqRes.status === 'fulfilled') {
-        const data = reqRes.value.data?.data ?? reqRes.value.data ?? [];
+      if (groupsRes.status === 'fulfilled') {
+        const data = groupsRes.value.data?.data ?? [];
         setGroups(Array.isArray(data) ? data : []);
       }
       if (delRes.status === 'fulfilled') {
@@ -352,11 +357,21 @@ const DeliverableGradingPage = () => {
           onChange={(e) => setSelectedGroup(e.target.value)}
         >
           <option value="">Select a group…</option>
-          {groups.map((g) => (
-            <option key={g.groupId ?? g.requestId} value={g.groupId}>
-              {g.groupName ?? g.name ?? g.groupId}
-            </option>
-          ))}
+          {groups.map((g) => {
+            const label = g.groupName ?? g.name ?? g.groupId;
+            const tag = g.role === 'jury'
+              ? ' [jury]'
+              : g.isOwnGroup
+              ? ' [own group]'
+              : g.role === 'advisor'
+              ? ' [committee advisor]'
+              : '';
+            return (
+              <option key={`${g.groupId}-${g.committeeId ?? ''}`} value={g.groupId}>
+                {label}{tag}
+              </option>
+            );
+          })}
         </select>
       </section>
 

--- a/frontend/src/pages/PhaseSchedulingPage.jsx
+++ b/frontend/src/pages/PhaseSchedulingPage.jsx
@@ -36,8 +36,7 @@ const formatErrorMessages = (message, defaultMessage = 'Failed to update phase s
   return [defaultMessage];
 };
 
-const getPhaseOptionLabel = (phase) =>
-  phase.name ? `${phase.name} (${phase.phaseId})` : phase.phaseId;
+const getPhaseOptionLabel = (phase) => phase.name || phase.phaseId;
 
 /* ─── design helpers ────────────────────────────────────────────── */
 function SectionLabel({ icon: Icon, children, action }) {

--- a/frontend/src/pages/SprintFinalizePage.jsx
+++ b/frontend/src/pages/SprintFinalizePage.jsx
@@ -33,9 +33,22 @@ function SprintFinalizePage() {
     };
   }, []);
 
+  // Sort by start date so option order matches sprint sequence (#1, #2, …).
+  // Backend returns createdAt-desc, which doesn't always match chronological
+  // sprint order and previously caused operators to pick the wrong sprint.
+  const orderedSprints = useMemo(() => {
+    const arr = [...sprints];
+    arr.sort((a, b) => {
+      const ad = a.startDate ? new Date(a.startDate).getTime() : Infinity;
+      const bd = b.startDate ? new Date(b.startDate).getTime() : Infinity;
+      return ad - bd;
+    });
+    return arr.map((s, i) => ({ ...s, sprintNumber: i + 1 }));
+  }, [sprints]);
+
   const selectedSprint = useMemo(
-    () => sprints.find((s) => s.sprintId === sprintId) || null,
-    [sprints, sprintId],
+    () => orderedSprints.find((s) => s.sprintId === sprintId) || null,
+    [orderedSprints, sprintId],
   );
 
   const handleSubmit = async (e) => {
@@ -61,11 +74,19 @@ function SprintFinalizePage() {
   };
 
   const sprintLabel = (s) => {
+    const num = `#${s.sprintNumber}`;
     const head = s.name || `Sprint`;
     const target =
       typeof s.targetStoryPoints === 'number' ? ` · ${s.targetStoryPoints} pts` : '';
+    const mappingCount = Array.isArray(s.deliverableMappings)
+      ? s.deliverableMappings.length
+      : 0;
+    const mappings =
+      mappingCount === 0
+        ? '  ⚠ NO deliverable mappings'
+        : ` · ${mappingCount} mapping${mappingCount === 1 ? '' : 's'}`;
     const finalized = s.isFinalized ? '  (already finalized)' : '';
-    return `${head}${target}${finalized}`;
+    return `${num} · ${head}${target}${mappings}${finalized}`;
   };
 
   return (
@@ -100,15 +121,20 @@ function SprintFinalizePage() {
             style={inputStyle}
           >
             <option value="">— Select a sprint —</option>
-            {sprints.map((s) => (
-              <option
-                key={s.sprintId}
-                value={s.sprintId}
-                disabled={s.isFinalized}
-              >
-                {sprintLabel(s)}
-              </option>
-            ))}
+            {orderedSprints.map((s) => {
+              const noMappings =
+                !Array.isArray(s.deliverableMappings) ||
+                s.deliverableMappings.length === 0;
+              return (
+                <option
+                  key={s.sprintId}
+                  value={s.sprintId}
+                  disabled={s.isFinalized || noMappings}
+                >
+                  {sprintLabel(s)}
+                </option>
+              );
+            })}
           </select>
           {selectedSprint?.isFinalized && (
             <div style={{ ...hintStyle, color: '#f59e0b' }}>

--- a/frontend/src/pages/admin/CommitteeDetailPage.jsx
+++ b/frontend/src/pages/admin/CommitteeDetailPage.jsx
@@ -499,6 +499,7 @@ function GradingScopeTab({ committeeId, advisorList }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [advisorDisplayMap, setAdvisorDisplayMap] = useState({})
+  const [juryList, setJuryList] = useState([])
 
   useEffect(() => {
     apiClient.get(apiConfig.endpoints.advisors, { params: { page: 1, limit: 100 } })
@@ -513,6 +514,18 @@ function GradingScopeTab({ committeeId, advisorList }) {
       })
       .catch(() => {})
   }, [])
+
+  // Load jury members for this committee — they share the scope dropdown
+  // with advisors so the coordinator can inspect either side's grading reach.
+  useEffect(() => {
+    apiClient
+      .get(`${apiConfig.endpoints.committeeJuryMembers(committeeId)}?page=1&limit=100`)
+      .then((r) => {
+        const list = r.data?.data ?? []
+        setJuryList(Array.isArray(list) ? list : [])
+      })
+      .catch(() => setJuryList([]))
+  }, [committeeId])
 
   const loadScope = useCallback(async (advisorId, p = 1) => {
     if (!advisorId) return
@@ -543,21 +556,39 @@ function GradingScopeTab({ committeeId, advisorList }) {
   return (
     <div className="space-y-4">
       <div>
-        <label className="block text-[11px] font-bold uppercase tracking-widest text-slate-400 mb-1.5">Advisor</label>
+        <label className="block text-[11px] font-bold uppercase tracking-widest text-slate-400 mb-1.5">
+          Committee Member
+        </label>
         <select
           value={selectedAdvisor}
           onChange={handleSelect}
           className="w-full sm:w-auto rounded-xl border border-[#1e293b] bg-[#111827] px-4 py-2.5 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-600/60"
         >
-          <option value="">— Select an advisor —</option>
-          {advisorList.map((a) => {
-            const uid = a.advisorUserId || a._id
-            return (
-              <option key={uid} value={uid}>
-                {advisorDisplayMap[uid] || uid}
-              </option>
-            )
-          })}
+          <option value="">— Select a member —</option>
+          {advisorList.length > 0 && (
+            <optgroup label="Advisors">
+              {advisorList.map((a) => {
+                const uid = a.advisorUserId || a._id
+                return (
+                  <option key={`adv-${uid}`} value={uid}>
+                    {advisorDisplayMap[uid] || a.email || uid}
+                  </option>
+                )
+              })}
+            </optgroup>
+          )}
+          {juryList.length > 0 && (
+            <optgroup label="Jury Members">
+              {juryList.map((j) => {
+                const uid = j.userId || j._id
+                return (
+                  <option key={`jury-${uid}`} value={uid}>
+                    {advisorDisplayMap[uid] || j.email || uid}
+                  </option>
+                )
+              })}
+            </optgroup>
+          )}
         </select>
       </div>
 
@@ -576,19 +607,31 @@ function GradingScopeTab({ committeeId, advisorList }) {
           <div className="divide-y divide-[#1e293b]">
             {items.map((item) => {
               const gid = item.groupId || item._id
+              const gname = item.groupName
               return (
                 <div key={gid} className="flex items-center justify-between py-3">
                   <div>
-                    <p className="text-sm font-mono text-slate-200">{gid}</p>
+                    {gname ? (
+                      <>
+                        <p className="text-sm font-semibold text-slate-100">{gname}</p>
+                        <p className="text-xs font-mono text-slate-500">{gid}</p>
+                      </>
+                    ) : (
+                      <p className="text-sm font-mono text-slate-200">{gid}</p>
+                    )}
                     <p className="mt-0.5 text-xs text-slate-500">
-                      Original advisor: {item.originalAdvisorId || item.advisorUserId || '—'}
+                      {item.isOwnGroup
+                        ? 'Primary advisor'
+                        : item.originalAdvisorUserId
+                        ? `Primary advisor: ${item.originalAdvisorUserId}`
+                        : 'Jury role'}
                       {item.assignedAt
                         ? ` · ${new Date(item.assignedAt).toLocaleString()}`
                         : ''}
                     </p>
                   </div>
                   <Badge
-                    label={item.isOwnGroup ? 'Own' : 'Other'}
+                    label={item.isOwnGroup ? 'Own' : 'Jury/Other'}
                     variant={item.isOwnGroup ? 'green' : 'default'}
                   />
                 </div>


### PR DESCRIPTION
## Summary
Migrates Teams + Grades modules to the global `SprintConfigEntry` model, lets every committee member (advisor or jury) grade deliverables and averages their grades per deliverable, fixes allowance-ratio = 0 regressions when sprint mappings and story-point records reference different sprintIds, and adds a Coordinator-only "finalize for all teams" flow with grade auto-recalculation. Also fixes 500s on committee advisor/jury list when seed data uses UUID IDs.

Closes #336 

---

## Type of Change
- [x] Feature (new endpoints + new behavior)
- [x] Bug fix
- [x] Refactor (Teams/Grades migration to single sprint-config model)
- [ ] Configuration / infrastructure
- [ ] Background job / scheduled task
- [x] Cross-cutting concern (auth check on `recordDeliverableEvaluation`)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change

**Backend:**
- Controller(s):
  - `committees/committees.controller.ts` — new `GET /committees/me/gradable-groups`; `:advisorUserId` no longer pinned to `ParseUUIDPipe`.
  - `teams/teams.controller.ts` — new `POST /teams/finalize-sprint-all` (Coordinator); enriches `studentRecords` with `studentName`, `studentEmail`.
  - `grades/grades.controller.ts` — passes `req.user.role` to `recordDeliverableEvaluation`.
- Use case(s) / service(s):
  - `committees/committees.service.ts` — `Types.ObjectId.isValid` filter on advisor/jury lookups; `groupName` join in `listCommitteeGroups`; `getAdvisorGradingScope` accepts jury members + adds `groupName`; new `getMyGradableGroups`, `assertCanGradeDeliverable`.
  - `grades/grades.service.ts` — `recordDeliverableEvaluation` enforces committee membership, upserts per `(groupId, deliverableId, gradedBy)`; step 8.4 averages `rawGrade` across graders; step 8.5/8.6 detects "informed" per-deliverable mapping and falls back to aggregate or full-participation appropriately; verbose structured logging.
  - `teams/teams-sync.service.ts` — uses `SprintConfigEntry`; `finalizeSprintSync` resolves `groupId` from team; advisor-panel adds `studentName`, `studentEmail`, per-student `finalGrade`/`individualAllowanceRatio`, group-level `teamGrade`/`teamGradeCalculatedAt`.
  - `teams/teams-cron.service.ts` — uses `SprintConfigEntry`; overdue detection joins `Schedule.endDatetime`.
  - `sprint-configs/sprint-configs.service.ts` — `findAll` / `findOne` / `create` / `update` enrich response with `name` / `startDate` / `endDate` / `isFinalized` from `Schedule`.
  - `sprint-evaluations/sprint-evaluations.service.ts` — drops obsolete `dto.deliverableId` from activity log metadata (was a build break).
- Repository / DB layer:
  - `grades/schemas/deliverable-evaluation.schema.ts` — unique index now `(groupId, deliverableId, gradedBy)`; non-unique `(groupId, deliverableId)` index for averaging lookups.
  - `sprint-configs/schemas/sprint-config.schema.ts` — adds `isFinalized` field.
- Schema / migration:
  - **Manual step required** (see Migration section).
- OpenAPI spec file(s):
  - To be updated alongside this PR (Process 5 + Process 8).

**Frontend:**
- `pages/SprintFinalizePage.jsx` — single sprint dropdown sorted by `startDate`, prefixed with `#1`, `#2`, …; shows mapping count and `⚠ NO deliverable mappings`; finalized + zero-mapping options disabled; calls new `/teams/finalize-sprint-all`; per-team result card with student-name table.
- `pages/admin/CommitteeDetailPage.jsx` — Groups tab shows `groupName`; Grading Scope tab adds Jury Members optgroup and shows `groupName` with role-aware subtitle.
- `pages/AdvisorSprintPanel.jsx` — student card shows name/email instead of ID, per-student final-grade badge, summary header includes Team Grade.
- `pages/DeliverableGradingPage.jsx` — uses `/committees/me/gradable-groups`; dropdown labels include role tag (`[own group]`, `[committee advisor]`, `[jury]`).
- `pages/GradeDisplayPage.jsx` — student view replaces single-row table with three big cards (My Final Grade, Team Grade, My Story Point Ratio).
- API client / DTO:
  - `config/api.js` — adds `myGradableGroups`, `finalizeSprintForAllTeams`.

**Infrastructure / Config:** N/A

---

## API Contract Alignment

| Field | Value |
|---|---|
| New endpoints | `GET /committees/me/gradable-groups`, `POST /teams/finalize-sprint-all` |
| New OperationIds | `getMyGradableGroups`, `finalizeSprintForAllTeams` |
| Modified endpoints | `POST /sprints` (validation), `POST /deliverable-evaluations` (auth check + per-grader upsert), `POST /teams/:teamId/finalize-sprint` (groupId optional), `GET /committees/:committeeId/jury-members` (no 500 on UUID), `GET /committees/:committeeId/advisors` (no 500 on UUID), `GET /committees/:committeeId/groups` (+ `groupName`), `GET /committees/:committeeId/advisors/:advisorUserId/groups` (jury accepted, + `groupName`), `GET /teams/:teamId/advisor-panel` (+ team grade + per-student grade + names) |
| OpenAPI file | `backend/openapi/process5.yaml`, `backend/openapi/process8.yaml` |
| Spec updated in this PR | **No** — to be done in a follow-up PR. |

- [x] Response shape matches OpenAPI schema for unchanged fields
- [ ] All documented status codes are reachable via implementation (manual verification pending)
- [x] No fields added to response that compromise the spec contract (only additive)
- [x] `gradedBy` extracted from JWT — NOT from request body

---

## Clean Architecture Checklist

**Infrastructure / API layer:**
- [x] Auth guard behavior matches status code matrix in issue
- [x] Controller returns contract-compliant response shape
- [x] Input validation rules enforced (`@ArrayMinSize(1)` on `deliverableMappings`)

**Application / Use Case layer:**
- [x] Use case orchestrates all validations before any DB write (committee check before upsert)
- [x] Sensitive fields never exposed in response DTOs (no JIRA/GitHub tokens leaked in any added payload)
- [x] Error mapping is deterministic — same input always produces same error code

**Domain / Repository layer:**
- [x] Repository queries enforce correct domain filters (`Types.ObjectId.isValid` filter; `groupId` scoping in story-point lookups)
- [x] Concurrency / uniqueness constraints protected at DB level (new compound unique index)
- [x] All DB failures caught and mapped to generic 500 — no raw cast errors reach the client

---

## Test Evidence

**Unit tests:**
- [ ] Happy path covered (TODO)
- [ ] All business-rule failure cases covered (TODO)
- [ ] Repository failure mapping tested (TODO)

**Controller tests:**
- [ ] 401 unauthorized
- [ ] 403 forbidden
- [ ] Success response shape and status code
- [ ] Validation error response (400)

**Integration / E2E tests:**
- [ ] Happy flow end-to-end
- [ ] Conflict / locked / not-found flow end-to-end
- [ ] Contract parity with OpenAPI verified

**Manual QA performed:**
- ✅ Coordinator finalize-for-all-teams: Sprint dropdown sorted by date with `#N` prefix; mapping count visible; selecting a sprint with mappings produces non-zero `teamGrade` and `individualAllowanceRatio` for every student.
- ✅ Jury + advisor both grade same deliverable: `step_8_4_deliverable_averaged` log shows both `rawGrade`s, `avgRawGrade` is the mean, `teamGrade` reflects average.
- ✅ Per-deliverable "informed" detection: data with sprintId mismatch now uses `aggregate_story_points` branch (`branchUsed` log) instead of zeroing out; data with matching sprintIds uses `per_deliverable_weighted` and trusts a true 0.
- ✅ Committee detail page: jury list, advisor list, groups list (with `groupName`), grading scope (with jury optgroup) all render without 500s.
- ✅ Deliverable grading page lists every committee group (own / advisor / jury) for the logged-in professor, not just primary-advised groups.

**Test file locations:**
- Unit: TBD
- Controller: TBD
- E2E: TBD

**Test run output:**
- Backend type check: ✅ `npx tsc --noEmit` clean (production code)
- Pre-existing test mocks updated where DTO shape changed (`sprint-configs.controller.spec.ts`)

---

## Status Code Matrix Verification

| Code | Scenario | Tested |
|---|---|---|
| 200 | `getMyGradableGroups`, list endpoints, `getAdvisorPanel`, `finalizeSprintForAllTeams` | ☑ manual |
| 201 | `recordDeliverableEvaluation` per-grader upsert | ☑ manual |
| 400 | Empty `deliverableMappings`, non-committee Professor calling `recordDeliverableEvaluation`, missing `sprintId` in finalize body | ☑ manual |
| 401 | Missing/invalid JWT (existing guard) | ☐ |
| 403 | Non-Coordinator calling `finalize-sprint-all` | ☐ |
| 404 | Committee/sprint/group not found | ☑ manual |
| 409 | Duplicate sprint-config `sprintId` | ☐ |
| 422 | `calculateGrade` with no deliverable evaluations | ☑ manual |
| 500 | Cast error path eliminated; remaining 500s logged with sanitized message | ☑ manual |

---

## Observability Checklist
- [x] Key business event is logged with structured payload (`event` field) — see Section 12 of issue for full event catalogue.
- [x] No secrets, tokens, hashes, or sensitive personal data in logs.
- [x] 500 responses include actionable internal context in server logs (`*_failed` events with `error` field).
- [ ] Audit log entry written (deliverable-evaluation already calls `activityLogsService.safeCreate`; finalize-for-all currently does not — to be added separately)

---

## Migration / Breaking Change Assessment
- [x] Database migration required — **manual one-shot step** documented below.
- [x] No breaking change to existing API consumers (additive only):
  - `POST /teams/:teamId/finalize-sprint` body still accepts `groupId` (now ignored).
  - `recordDeliverableEvaluation` request body unchanged — only auth gate added.
  - All response enrichments are additive.
- [x] Backward compatibility note: Old `SprintConfig` (story-points/schemas) and its `sprintconfigs` collection become dead code. They can be removed in a follow-up. Existing `SprintConfigEntry` documents that lack `deliverableMappings` are now invalid for new finalize runs (UI disables them); they should be patched (PATCH `/sprints/:sprintId`) or deleted before the next sprint cycle.

### Manual migration step
Run on the target Mongo instance **after** deploying:
```js
// drop the old (groupId, deliverableId) unique index that blocked per-grader writes
db.deliverableevaluations.dropIndex("groupId_1_deliverableId_1");
// Mongoose will auto-create the new (groupId, deliverableId, gradedBy) unique index on next boot.
```

---

## Out of Scope Confirmation
The following are explicitly NOT implemented in this PR:
- OpenAPI spec updates for the new + modified endpoints (separate PR).
- Removal of legacy `SprintConfig` schema in `story-points/schemas/` (left as dead code).
- Per-grader weighting (each grader counts equally).
- UI to backfill `deliverableMappings` on already-created sprint configs.
- Sprint name field in `Schedule` (current label is computed from `startDate`/`endDate`).
- Mongoose `new` option deprecation warnings.

---

## Dependencies
- Blocked by: none
- Must be merged before: OpenAPI spec PR
- Requires Issue 47 (Audit logging) to be merged first: No

---

## Reviewer Notes
- The "informed vs uninformed" detection in step 8.5/8.6 is the subtlest piece — please review the symmetry: when a sprint mapping intersects the student's sprint records, a true 0 is preserved; when it does not, fallback aggregates from all the student's group-scoped story-point records.
- `recordDeliverableEvaluation` membership check uses inline `committeeModel.findOne` (not `committeesService.assertCanGradeDeliverable`) to avoid a `GradesService → CommitteesService` dependency. Helper exists for callers that don't already have `committeeModel`.
- DB index drop in the migration step is one-shot and idempotent (re-run is a no-op).

---

## Definition of Done Sign-off
- [x] Implementation type-checks; manual QA paths verified.
- [ ] Automated tests added (TODO).
- [ ] OpenAPI spec updated and aligned (separate PR).
- [x] No TODO comments left in production code.
- [x] No `console.log` or debug statements in code.
