### PR TITLE
review page works now for prof

### DIFF
--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -66,9 +66,6 @@ export class ReviewsController {
   @ApiBadRequestResponse({ description: 'Request validation failed' })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
   @ApiForbiddenResponse({ description: 'Caller is not in the committee jury' })
-  @ApiConflictResponse({
-    description: 'Review already exists for this reviewer and submission',
-  })
   @ApiNotFoundResponse({ description: 'Submission or committee not found' })
   @Post()
   @Roles(Role.Professor)

--- a/backend/src/reviews/reviews.service.spec.ts
+++ b/backend/src/reviews/reviews.service.spec.ts
@@ -1,5 +1,4 @@
 import {
-  ConflictException,
   ForbiddenException,
   HttpException,
   NotFoundException,
@@ -137,17 +136,22 @@ describe('ReviewsService', () => {
     expect(sub.save).toHaveBeenCalled();
   });
 
-  it('rejects duplicate reviews for the same reviewer and submission', async () => {
+  it('returns the existing review for the same reviewer and submission', async () => {
     mockSubmissionModel.findById.mockReturnValue(execResult(submission()));
     mockCommitteeModel.findOne.mockReturnValue(execResult(committee()));
-    mockReviewModel.findOne.mockReturnValue(execResult(review()));
+    const existing = review();
+    mockReviewModel.findOne.mockReturnValue(execResult(existing));
 
     await expect(
       service.createReview(
         { submissionId: 'sub-1', committeeId: 'committee-1' },
         { userId: 'prof-1' },
       ),
-    ).rejects.toThrow(ConflictException);
+    ).resolves.toMatchObject({
+      reviewId: existing.reviewId,
+      submissionId: existing.submissionId,
+      reviewerUserId: existing.reviewerUserId,
+    });
   });
 
   it('adds a comment for the owning reviewer', async () => {

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -212,9 +212,7 @@ export class ReviewsService {
       .findOne({ submissionId: dto.submissionId, reviewerUserId })
       .exec();
     if (existing) {
-      throw new ConflictException(
-        'Review already exists for this reviewer and submission.',
-      );
+      return this.toReviewResponse(existing);
     }
 
     const review = new this.reviewModel({

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,4 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import { AuthProvider } from './context/AuthContext';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { useAuth } from './context/AuthContext';
@@ -77,7 +76,7 @@ function App() {
             <Route path="/documents" element={<StudentSubmissionPage />} />
             <Route path="/my-submissions" element={<DocumentsPage />} />
             <Route path="/grades" element={<GradeDisplayPage />} />
-            <Route path="/professor/submissions" element={<DocumentsPage />} />
+            <Route path="/professor/submissions" element={<Navigate to="/review" replace />} />
             <Route
               path="/review"
               element={
@@ -90,7 +89,14 @@ function App() {
             <Route path="/integrations" element={<IntegrationsPage />} />
             <Route path="/scrum" element={<ScrumManagementPage />} />
             <Route path="/advisor/requests" element={<AdvisorRequestsPage />} />
-            <Route path="/advisor/sprint-evaluation" element={<SprintEvaluationPage />} />
+            <Route
+              path="/advisor/sprint-evaluation"
+              element={
+                <ProtectedRoute requiredRole="Professor">
+                  <SprintEvaluationPage />
+                </ProtectedRoute>
+              }
+            />
             <Route
               path="/professor/deliverable-grading"
               element={
@@ -99,7 +105,14 @@ function App() {
                 </ProtectedRoute>
               }
             />
-            <Route path="/advisor/sprint-panel" element={<AdvisorSprintPanel />} />
+            <Route
+              path="/advisor/sprint-panel"
+              element={
+                <ProtectedRoute requiredRoles={['Professor', 'Coordinator']}>
+                  <AdvisorSprintPanel />
+                </ProtectedRoute>
+              }
+            />
             <Route
               path="/coordinator/sprint-finalize"
               element={
@@ -139,8 +152,6 @@ function App() {
                 </ProtectedRoute>
               }
             />
-            <Route path="/phases" element={<Navigate to="/phases/schedule" replace />} />
-            <Route path="/committees" element={<Navigate to="/admin/committees" replace />} />
             <Route path="/advisors" element={<Navigate to="/admin/advisors" replace />} />
             <Route
               path="/committees"

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,11 +1,10 @@
 import { Navigate, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { useAuth } from '../context/AuthContext';
+import { hasAnyRole, hasRole } from '../utils/roleUtils';
 
-const normalizeRole = (role) => String(role || '').trim().toLowerCase();
-
-export const ProtectedRoute = ({ children, requiredRole }) => {
-  const { isAuthenticated, isLoading } = useAuth();
+export const ProtectedRoute = ({ children, requiredRole, requiredRoles }) => {
+  const { isAuthenticated, isLoading, user } = useAuth();
   const location = useLocation();
 
   if (isLoading) {
@@ -16,15 +15,11 @@ export const ProtectedRoute = ({ children, requiredRole }) => {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
-  let user = null;
-  try {
-    const userStr = localStorage.getItem('user');
-    user = userStr ? JSON.parse(userStr) : null;
-  } catch {
-    user = null;
-  }
+  const roleMismatch =
+    (requiredRole && !hasRole(user?.role, requiredRole)) ||
+    (requiredRoles && !hasAnyRole(user?.role, requiredRoles));
 
-  if (requiredRole && normalizeRole(user?.role) !== normalizeRole(requiredRole)) {
+  if (roleMismatch) {
     return <Navigate to="/dashboard" replace />;
   }
 
@@ -34,4 +29,5 @@ export const ProtectedRoute = ({ children, requiredRole }) => {
 ProtectedRoute.propTypes = {
   children: PropTypes.node.isRequired,
   requiredRole: PropTypes.string,
+  requiredRoles: PropTypes.arrayOf(PropTypes.string),
 };

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -100,7 +100,6 @@ export const Sidebar = () => {
           <>
             <SectionHeader label="Professor" />
             <SideNavLink to="/review" icon={ClipboardCheck} label="Review" />
-            <SideNavLink to="/professor/submissions" icon={FileText} label="Submissions" />
             <SideNavLink to="/professor/deliverable-grading" icon={GraduationCap} label="Deliverable Grading" />
             <SideNavLink to="/advisor/sprint-evaluation" icon={Star} label="Sprint Evaluation" />
             <SideNavLink to="/advisor/sprint-panel" icon={Activity} label="Sprint Panel" />

--- a/frontend/src/components/reviews/SubmissionReviewPanel.jsx
+++ b/frontend/src/components/reviews/SubmissionReviewPanel.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { FileText, MessageSquare, GitPullRequest, Star, Trash2 } from 'lucide-react'
 import apiConfig from '../../config/api'
@@ -16,7 +16,13 @@ import { Badge } from '../ui'
 const getId = (value) => value?._id || value?.id || value?.reviewId || value?.commentId
 
 const getAuthorId = (comment) =>
-  comment?.authorUserId || comment?.userId || comment?.createdByUserId || comment?.author?.userId || comment?.author?.id
+  comment?.authorUserId ||
+  comment?.userId ||
+  comment?.createdByUserId ||
+  comment?.createdBy?.userId ||
+  comment?.author?.userId ||
+  comment?.author?.id ||
+  comment?.author?._id
 
 const getAuthorName = (comment) =>
   comment?.authorName || comment?.author?.name || comment?.author?.email || getAuthorId(comment) || 'Committee member'
@@ -57,9 +63,14 @@ const SubmissionReviewPanel = ({ submission, committeeId, currentUser }) => {
   const [gradingWindow, setGradingWindow] = useState({ isOpen: false })
   const [status, setStatus] = useState({ loading: true, message: '', error: '' })
   const [saving, setSaving] = useState(false)
+  const reviewIdCacheRef = useRef(new Map())
 
   const submissionId = submission?._id || submission?.id || submission?.submissionId
-  const existingReviewId = submission?.reviewId || submission?.review?._id || submission?.review?.id
+  const existingReviewId =
+    submission?.reviewId ||
+    submission?.review?.reviewId ||
+    submission?.review?._id ||
+    submission?.review?.id
   const userId = currentUser?.userId || currentUser?.id || currentUser?._id
   const isSubmitted = review?.status === 'Submitted' || review?.grade !== undefined
 
@@ -78,14 +89,26 @@ const SubmissionReviewPanel = ({ submission, committeeId, currentUser }) => {
     if (!submissionId || !committeeId) return
     setStatus({ loading: true, message: '', error: '' })
     try {
-      const data = existingReviewId
-        ? await getReview(existingReviewId)
+      const cachedReviewId = reviewIdCacheRef.current.get(String(submissionId))
+      const resolvedReviewId = existingReviewId || cachedReviewId
+      const data = resolvedReviewId
+        ? await getReview(resolvedReviewId)
         : await createReview(submissionId, committeeId)
+      const dataReviewId = getId(data)
+      if (dataReviewId) {
+        reviewIdCacheRef.current.set(String(submissionId), dataReviewId)
+      }
       setReview(normalizeReview(data))
       setGrade(data?.grade ?? '')
       setStatus({ loading: false, message: '', error: '' })
     } catch (error) {
-      setStatus({ loading: false, message: '', error: error.message || 'Unable to load review.' })
+      setStatus({
+        loading: false,
+        message: '',
+        error:
+          error.message ||
+          'Unable to load review. Refresh the queue if this submission was already reviewed.',
+      })
     }
   }, [committeeId, existingReviewId, submissionId])
 
@@ -100,6 +123,9 @@ const SubmissionReviewPanel = ({ submission, committeeId, currentUser }) => {
   const refreshReview = async (nextReviewId = getId(review)) => {
     if (!nextReviewId) return
     const data = await getReview(nextReviewId)
+    if (submissionId && nextReviewId) {
+      reviewIdCacheRef.current.set(String(submissionId), String(nextReviewId))
+    }
     setReview(normalizeReview(data))
     setGrade(data?.grade ?? '')
   }

--- a/frontend/src/components/reviews/SubmissionReviewPanel.test.jsx
+++ b/frontend/src/components/reviews/SubmissionReviewPanel.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SubmissionReviewPanel from './SubmissionReviewPanel'
-import { createReview } from '../../utils/reviewService'
+import { createReview, getReview } from '../../utils/reviewService'
 import { getGradingWindow } from '../../utils/scheduleService'
 
 vi.mock('../../utils/reviewService', () => ({
@@ -38,6 +38,12 @@ describe('SubmissionReviewPanel', () => {
       revisionRequests: [],
       status: 'UnderReview',
     })
+    getReview.mockResolvedValue({
+      _id: 'review-1',
+      comments: [],
+      revisionRequests: [],
+      status: 'UnderReview',
+    })
   })
 
   it('disables the grade input when the grading window is closed', async () => {
@@ -69,5 +75,56 @@ describe('SubmissionReviewPanel', () => {
     expect(await screen.findByText('My comment')).toBeTruthy()
     expect(screen.getByText('Other comment')).toBeTruthy()
     expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(1)
+  })
+
+  it('reuses cached review id when submission is selected again', async () => {
+    createReview
+      .mockResolvedValueOnce({
+        _id: 'review-1',
+        comments: [],
+        revisionRequests: [],
+        status: 'UnderReview',
+      })
+      .mockResolvedValueOnce({
+        _id: 'review-2',
+        comments: [],
+        revisionRequests: [],
+        status: 'UnderReview',
+      })
+
+    const { rerender } = render(
+      <SubmissionReviewPanel
+        committeeId="committee-1"
+        currentUser={{ userId: 'prof-1' }}
+        submission={submission}
+      />,
+    )
+
+    await screen.findByText('No comments yet.')
+    expect(createReview).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <SubmissionReviewPanel
+        committeeId="committee-1"
+        currentUser={{ userId: 'prof-1' }}
+        submission={{ ...submission, _id: 'submission-2' }}
+      />,
+    )
+    await waitFor(() => {
+      expect(createReview).toHaveBeenCalledTimes(2)
+    })
+
+    rerender(
+      <SubmissionReviewPanel
+        committeeId="committee-1"
+        currentUser={{ userId: 'prof-1' }}
+        submission={submission}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(getReview).toHaveBeenCalledWith('review-1')
+      expect(createReview).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/frontend/src/pages/DeliverableGradingPage.jsx
+++ b/frontend/src/pages/DeliverableGradingPage.jsx
@@ -4,12 +4,10 @@ import { ChevronDown, ChevronRight, BookOpen, Package } from 'lucide-react';
 import apiClient from '../utils/apiClient';
 import apiConfig from '../config/api';
 import { PageHeader } from '../components/ui';
+import { useAuth } from '../context/AuthContext';
 
 const SOFT_GRADES = ['A', 'B', 'C', 'D', 'F'];
 const BINARY_GRADES = ['S', 'F'];
-
-// Binary S (Satisfactory) → A, F → F  (backend only accepts A/B/C/D/F)
-const binaryToSoft = (g) => (g === 'S' ? 'A' : 'F');
 
 const inputCls =
   'w-full rounded-md border border-[#26262b] bg-[#0a0a0b] px-3.5 py-2.5 text-[13px] text-zinc-200 transition-colors focus:border-[#3a3a40] focus:outline-none focus:ring-1 focus:ring-[#3a3a40]';
@@ -116,8 +114,13 @@ function DeliverableCard({ deliverable, groupId }) {
       // Auto-trigger grade calculation so student final grades are updated immediately
       try {
         await apiClient.post(`/groups/${groupId}/calculate`, { force: true });
-      } catch {
-        // Calculation errors are non-fatal; grade was still recorded
+      } catch (calcError) {
+        const calcMessage = calcError?.response?.data?.message;
+        const details = Array.isArray(calcMessage) ? calcMessage.join(', ') : calcMessage;
+        toast(
+          `Grade saved, but final grade recalculation failed.${details ? ` ${details}` : ''}`,
+          { icon: '⚠️' },
+        );
       }
       toast.success(
         `Grade "${calculatedGrade}" submitted for ${deliverable.name ?? 'deliverable'}.`,
@@ -311,12 +314,17 @@ function DeliverableCard({ deliverable, groupId }) {
 }
 
 const DeliverableGradingPage = () => {
+  const { user } = useAuth();
   const [groups, setGroups] = useState([]);
   const [deliverables, setDeliverables] = useState([]);
   const [selectedGroup, setSelectedGroup] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     const load = async () => {
+      setLoading(true);
+      setError('');
       // Lists every group the caller can grade deliverables for — both
       // groups they advise directly and groups they jury via committee
       // membership. Sprint evaluations remain advisor-only and are gated
@@ -333,6 +341,15 @@ const DeliverableGradingPage = () => {
         const data = delRes.value.data?.data ?? delRes.value.data ?? [];
         setDeliverables(Array.isArray(data) ? data : []);
       }
+      const errors = [];
+      if (groupsRes.status === 'rejected') errors.push('groups');
+      if (delRes.status === 'rejected') errors.push('deliverables');
+      if (errors.length > 0) {
+        const nextError = `Failed to load ${errors.join(' and ')}. Please refresh and try again.`;
+        setError(nextError);
+        toast.error(nextError);
+      }
+      setLoading(false);
     };
     load();
   }, []);
@@ -342,8 +359,22 @@ const DeliverableGradingPage = () => {
       <PageHeader
         eyebrow="Professor"
         title="Deliverable Grading"
-        subtitle="Select a group, then grade each deliverable using its rubric criteria."
+        subtitle={`Select a group, then grade each deliverable using its rubric criteria.${
+          user?.name ? ` Signed in as ${user.name}.` : ''
+        }`}
       />
+
+      {loading && (
+        <div className="rounded-2xl border border-[#1f1f23] bg-[#131316] p-5">
+          <p className="text-[13px] text-zinc-500">Loading groups and deliverables…</p>
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
 
       {/* Group selector */}
       <section className="rounded-2xl border border-[#1f1f23] bg-[#131316] p-5">
@@ -376,7 +407,7 @@ const DeliverableGradingPage = () => {
       </section>
 
       {/* Deliverables list */}
-      {selectedGroup ? (
+      {!loading && selectedGroup ? (
         <section className="space-y-2">
           <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
             Deliverables — click to expand and grade
@@ -393,11 +424,11 @@ const DeliverableGradingPage = () => {
             ))
           )}
         </section>
-      ) : (
+      ) : !loading ? (
         <p className="text-center text-[13px] text-zinc-600">
           ← Select a group to start grading
         </p>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -8,6 +8,8 @@ import {
 import apiClient from '../utils/apiClient'
 import apiConfig from '../config/api'
 import { PageHeader, Badge } from '../components/ui'
+import { useAuth } from '../context/AuthContext'
+import { hasRole } from '../utils/roleUtils'
 
 const normalizeList = (payload) => {
   if (Array.isArray(payload)) return payload
@@ -50,17 +52,8 @@ const findProfessorCommittee = (committees, user) => {
   )
 }
 
-const getStoredUser = () => {
-  try {
-    const raw = localStorage.getItem('user')
-    return raw ? JSON.parse(raw) : null
-  } catch {
-    return null
-  }
-}
-
 const ReviewPage = () => {
-  const [user, setUser] = useState(null)
+  const { user } = useAuth()
   const [committee, setCommittee] = useState(null)
   const [committeeFromGroup, setCommitteeFromGroup] = useState(null)
   const [submissions, setSubmissions] = useState([])
@@ -78,10 +71,7 @@ const ReviewPage = () => {
   )
 
   const loadReviewQueue = useCallback(async () => {
-    const localUser = getStoredUser()
-    setUser(localUser)
-
-    if (!localUser) {
+    if (!user) {
       setStatus({ loading: false, error: 'User session not found. Please sign in again.' })
       return
     }
@@ -90,15 +80,14 @@ const ReviewPage = () => {
       setStatus({ loading: true, error: '' })
 
       const directCommitteeId =
-        localUser.committeeId ||
-        localUser.assignedCommitteeId ||
-        localUser.committee?.id ||
-        localUser.committee?._id
+        user.committeeId || user.assignedCommitteeId || user.committee?.id || user.committee?._id
 
       let professorCommittee = null
       if (directCommitteeId) {
         professorCommittee = await getCommittee(directCommitteeId)
-      } else if (String(localUser.role || '').toLowerCase() === 'professor') {
+      }
+
+      if (!professorCommittee && hasRole(user.role, 'Professor')) {
         const queue = normalizeList(await listProfessorReviewSubmissions())
         setCommittee(null)
         setCommitteeFromGroup(null)
@@ -108,9 +97,11 @@ const ReviewPage = () => {
         )
         setStatus({ loading: false, error: '' })
         return
-      } else {
+      }
+
+      if (!professorCommittee) {
         const committees = normalizeList(await listCommittees({ page: 1, limit: 100 }))
-        professorCommittee = findProfessorCommittee(committees, localUser) || null
+        professorCommittee = findProfessorCommittee(committees, user) || null
       }
 
       const committeeId = getCommitteeId(professorCommittee)
@@ -134,7 +125,7 @@ const ReviewPage = () => {
         error: error.message || 'Unable to load review queue.',
       })
     }
-  }, [])
+  }, [user])
 
   useEffect(() => {
     const task = window.setTimeout(loadReviewQueue, 0)

--- a/frontend/src/utils/roleUtils.js
+++ b/frontend/src/utils/roleUtils.js
@@ -1,0 +1,7 @@
+export const normalizeRole = (role) => String(role || '').trim().toLowerCase();
+
+export const hasRole = (role, expectedRole) =>
+  normalizeRole(role) === normalizeRole(expectedRole);
+
+export const hasAnyRole = (role, expectedRoles = []) =>
+  expectedRoles.some((expectedRole) => hasRole(role, expectedRole));


### PR DESCRIPTION
## Summary
<!-- One or two sentences describing what this PR does and why. -->

Fixes the Professor review flow: removes duplicate `/committees` and `/phases` route registrations, aligns sidebar links with route guards, redirects `/professor/submissions` to `/review`, centralizes role normalization for `ProtectedRoute`, switches `ReviewPage` and `DeliverableGradingPage` to `AuthContext`, improves deliverable grading loading/error UX, hardens `SubmissionReviewPanel` review loading (cached review IDs, broader review id fields), and makes `POST /reviews` idempotent when a review already exists so professors can add comments and request revisions without hitting conflicts after reload or resubmission.

Closes #339 

---

## Type of Change
<!-- Check all that apply -->
- [ ] Feature (new endpoint or business logic)
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Configuration / infrastructure
- [ ] Background job / scheduled task
- [ ] Cross-cutting concern (middleware, guards, interceptors)
- [ ] OpenAPI spec update only
- [ ] Test-only change

---

## Scope of Change
<!-- List the files, modules, or layers touched. Be specific. -->

**Backend:**
- Controller(s): `reviews.controller.ts` (Swagger conflict doc removed for create review where behavior is now idempotent)
- Use case(s) / service(s): `reviews.service.ts` — `createReview` returns existing review for same reviewer + submission instead of throwing conflict
- Repository / DB layer: unchanged
- Schema / migration: none
- OpenAPI spec file(s): not updated in repo (see API Contract Alignment)

**Frontend:** (if applicable)
- Component(s): `ProtectedRoute.jsx`, `Sidebar.jsx`, `SubmissionReviewPanel.jsx`, `SubmissionReviewPanel.test.jsx`
- Pages: `App.jsx`, `ReviewPage.jsx`, `DeliverableGradingPage.jsx`
- Utils: `roleUtils.js` (new)

**Infrastructure / Config:** (if applicable)
- N/A

---

## API Contract Alignment
<!-- Only fill in if this PR touches an endpoint -->

| Field | Value |
|---|---|
| Endpoint | `POST /api/v1/reviews` |
| OperationId | createReview |
| OpenAPI file | process4.yaml / process5.yaml |
| Spec updated in this PR | No — recommend follow-up if spec still documents 409 for duplicate create |

- [ ] Response shape matches OpenAPI schema exactly (success path unchanged; 409 may no longer apply for duplicate create)
- [ ] All documented status codes are reachable via implementation
- [ ] No fields added to response that are not in the spec
- [ ] groupId / actorId extracted from JWT — NOT from request body (if applicable)

---

## Clean Architecture Checklist
<!-- Verify the layer boundaries defined in the issue acceptance criteria -->

**Infrastructure / API layer:**
- [x] Auth guard behavior matches status code matrix in issue (unchanged for this endpoint)
- [x] Controller returns contract-compliant response shape (same DTO on success)
- [x] Input validation rules enforced (required fields, UUID format, enum values)

**Application / Use Case layer:**
- [x] Use case orchestrates all validations before any DB write
- [x] Sensitive fields never exposed in response DTOs
- [x] Error mapping is deterministic — same input always produces same error code

**Domain / Repository layer:**
- [x] Repository queries enforce correct domain filters (role scoping, ownership)
- [x] Concurrency / uniqueness constraints protected at DB level, not only application level
- [x] All DB failures caught and mapped to generic 500 — no raw DB errors reach the client

---

## Test Evidence
<!-- Fill in what was tested. Link to test files where possible. -->

**Unit tests:**
- [x] Happy path covered (`reviews.service.spec.ts`, `SubmissionReviewPanel.test.jsx`)
- [ ] All business-rule failure cases covered (see Section 11 of issue)
- [ ] Repository failure mapping tested

**Controller tests:**
- [ ] 401 unauthorized (missing/invalid JWT)
- [ ] 403 forbidden (wrong role or ownership mismatch)
- [ ] Success response shape and status code
- [ ] Validation error response (400)

**Integration / E2E tests:**
- [ ] Happy flow end-to-end
- [ ] Conflict / locked / not-found flow end-to-end
- [ ] Contract parity with OpenAPI verified

**Test file locations:**
- Unit: `backend/src/reviews/reviews.service.spec.ts`, `frontend/src/components/reviews/SubmissionReviewPanel.test.jsx`
- Controller: N/A for this PR
- E2E: N/A run for this PR

**Test run output:**
<!-- Paste summary or screenshot of test results — pass count, failure count -->

- Backend: `npm test -- reviews.service.spec.ts` — pass (11 tests)
- Frontend: `npx vitest run src/components/reviews/SubmissionReviewPanel.test.jsx` — pass (3 tests)
- Full `frontend` lint / full suite: run before merge per CONTRIBUTING.md

---

## Status Code Matrix Verification
<!-- Confirm every documented status code is reachable -->

| Code | Scenario | Tested |
|---|---|---|
| 2xx | Happy path | ☑ |
| 400 | Validation failure | ☐ |
| 401 | Missing/invalid JWT | ☐ |
| 403 | Role or ownership mismatch | ☐ |
| 404 | Resource not found | ☐ |
| 409 | Conflict | ☐ — behavior changed: duplicate create may now return 200-style success body instead of 409; verify spec |
| 4xx | Other (specify) | ☐ |
| 500 | DB/internal failure | ☐ |

<!-- Remove rows not applicable to this PR -->

---

## Observability Checklist
<!-- From Section 12 of issue -->
- [ ] Key business event is logged with correlationId / requestId
- [x] No secrets, tokens, hashes, or sensitive personal data in logs
- [ ] 500 responses include actionable internal context in server logs
- [ ] Audit log entry written (if this is a POST, PATCH, or DELETE operation — requires Issue 47 to be merged first)

---

## Migration / Breaking Change Assessment
- [x] No database migration required
- [ ] Migration included and tested with rollback plan
- [ ] No breaking change to API contract — **note:** success-on-duplicate `POST /reviews` may be a semantic contract change for clients that relied on 409
- [ ] Breaking change — existing consumers notified: [describe]
- [ ] Backward compatibility note: Clients that retried create after conflict now get existing review instead of error — generally safer for idempotent clients

---

## Out of Scope Confirmation
<!-- From Section 14 of issue — confirm these were NOT implemented -->
The following are explicitly out of scope for this PR and were not implemented:
- New backend endpoints or DTO/schema changes beyond idempotent `createReview` behavior
- Visual redesign of Review or Deliverable Grading pages
- OpenAPI YAML updates (flagged above for optional follow-up)
- Coordinator / Student sidebar sections (unchanged except as noted)
- Full frontend `npm run lint` / `npm run test` suite evidence — **complete before merge**

---

## Dependencies
<!-- List any PRs, issues, or external changes this PR depends on -->
- Blocked by: #
- Must be merged before: #
- Requires Issue 47 (Audit logging) to be merged first: No

---

## Reviewer Notes
<!-- Anything specific you want reviewers to focus on or be aware of -->
- Confirm duplicate `POST /reviews` idempotency matches product expectations and update OpenAPI if 409 is removed from the matrix.
- Manually verify `/review`: Add Comment and Request Revision after selecting a submission (especially after refresh / switching submissions).
- `ProtectedRoute` now supports `requiredRoles` for shared routes (e.g. sprint panel).

---

## Definition of Done Sign-off
- [ ] Implementation merged with passing tests
- [ ] OpenAPI spec updated and aligned with implementation (if duplicate-create behavior is documented)
- [ ] QA scenarios executed and evidenced above
- [ ] PR description includes test evidence and status-matrix coverage
- [x] No TODO comments left in production code
- [x] No console.log or debug statements left in code